### PR TITLE
Update background color syntax

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -10,7 +10,10 @@
     "light": "#F393B0",
     "dark": "#C9134A",
     "ultraLight": "#FBECF1",
-    "ultraDark": "#A40031"
+    "ultraDark": "#A40031",
+    "background": {
+      "dark": "#121212"
+    }
   },
   "topbarCtaButton": {
     "name": "Sign Up",
@@ -70,7 +73,7 @@
   ],
   "analytics": {
     "ga4": {
-        "measurementId": "G-7SBXER6DHL"
+      "measurementId": "G-7SBXER6DHL"
     }
   },
   "footerSocials": {


### PR DESCRIPTION
# Summary

We recently updated the syntax for the background colors, and have adjusted the `mint.json` configuration to preserve the intended theme

<img width="1156" alt="cerebrium-background" src="https://user-images.githubusercontent.com/44352119/202921713-b9207599-0370-4954-b0f9-c1ca478db46c.png">
