### PR TITLE
Add graceful termination docs

### DIFF
--- a/cerebrium/scaling/graceful-termination.mdx
+++ b/cerebrium/scaling/graceful-termination.mdx
@@ -1,0 +1,34 @@
+---
+title: "Graceful Termination"
+description: "Handle instance shutdown to prevent 502 errors during scaling"
+---
+
+Cerebrium terminates instances during scaling and redeployments. Proper graceful termination ensures active requests complete successfully rather than failing with 502 errors.
+
+## How Termination Works
+
+When Cerebrium needs to terminate an instance:
+
+1. Stops routing new requests to the instance
+2. Sends SIGTERM signal to your application
+3. Waits for `response_grace_period` seconds
+4. Sends SIGKILL if the instance has not stopped
+
+## Configuration
+
+Configure the grace period in your `cerebrium.toml` file:
+```toml
+[cerebrium.scaling]
+response_grace_period = 300  # Seconds to wait before force termination
+
+<Warning>
+Without `response_grace_period`, instances are force-killed immediately, causing 502 errors.
+</Warning>
+
+Set to 1.5x your maximum expected request duration.
+
+Runtime Behavior
+Cortex Runtime (Default): SIGTERM handled automatically. Just configure response_grace_period.
+Custom Runtime: You must handle SIGTERM in your application code.
+
+FastAPI Implementation

--- a/cerebrium/scaling/graceful-termination.mdx
+++ b/cerebrium/scaling/graceful-termination.mdx
@@ -1,34 +1,109 @@
----
 title: "Graceful Termination"
-description: "Handle instance shutdown to prevent 502 errors during scaling"
+description: "Prevent 502 errors during instance shutdown"
 ---
 
-Cerebrium terminates instances during scaling and redeployments. Proper graceful termination ensures active requests complete successfully rather than failing with 502 errors.
+Cerebrium instances are subject to termination during scaling events and redeployments. Without proper configuration, active requests fail with 502 errors when instances are killed mid-execution.
 
-## How Termination Works
+Instance terminations are common during normal operations. Applications with long-running tasks (model inference, video processing, etc.) must handle termination gracefully, as the likelihood of interruption increases with task duration.
 
-When Cerebrium needs to terminate an instance:
+## Preparing for Termination
 
-1. Stops routing new requests to the instance
-2. Sends SIGTERM signal to your application
-3. Waits for `response_grace_period` seconds
-4. Sends SIGKILL if the instance has not stopped
-
-## Configuration
-
-Configure the grace period in your `cerebrium.toml` file:
+Configure `response_grace_period` in `cerebrium.toml`:
 ```toml
 [cerebrium.scaling]
-response_grace_period = 300  # Seconds to wait before force termination
+response_grace_period = 300  # Seconds before force-kill
 
 <Warning>
-Without `response_grace_period`, instances are force-killed immediately, causing 502 errors.
+Without this configuration, Cerebrium force-kills instances immediately, causing 502 errors.
 </Warning>
+When termination occurs, Cerebrium:
 
-Set to 1.5x your maximum expected request duration.
+Stops routing new requests
+Sends SIGTERM signal
+Waits response_grace_period seconds
+Sends SIGKILL
 
-Runtime Behavior
-Cortex Runtime (Default): SIGTERM handled automatically. Just configure response_grace_period.
-Custom Runtime: You must handle SIGTERM in your application code.
+Set to 1.5x your longest expected request duration.
+Runtime-Specific Handling
+Cortex Runtime (Default): Automatic - SIGTERM is captured and requests complete before termination.
+Custom Runtime: You must implement SIGTERM handling in your application code.
 
-FastAPI Implementation
+Custom Runtime Implementation
+FastAPI
+Implement the lifespan pattern to track active requests:
+
+from fastapi import FastAPI, HTTPException
+from contextlib import asynccontextmanager
+import asyncio
+
+active_requests = 0
+shutting_down = False
+lock = asyncio.Lock()
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    yield
+    
+    global shutting_down
+    shutting_down = True
+    
+    while active_requests > 0:
+        await asyncio.sleep(1)
+
+app = FastAPI(lifespan=lifespan)
+
+@app.middleware("http")
+async def track_requests(request, call_next):
+    global active_requests
+    if shutting_down:
+        raise HTTPException(503, "Shutting down")
+    
+    async with lock:
+        active_requests += 1
+    try:
+        return await call_next(request)
+    finally:
+        async with lock:
+            active_requests -= 1
+
+Critical: Entrypoint Configuration
+Your entrypoint must use exec to ensure SIGTERM reaches the application:
+dockerfileENTRYPOINT ["exec", "fastapi", "run", "app.py", "--port", "8000"]
+
+Or in bash scripts:
+bashexec fastapi run app.py --port ${PORT:-8000}
+Without exec, SIGTERM is sent to the shell (PID 1) instead of your application, and graceful shutdown never executes.
+
+Best Practices
+
+Checkpoint long operations - Save progress frequently for tasks exceeding the grace period
+Make operations idempotent - Ensure interrupted tasks can safely retry
+Explicit resource cleanup - Release GPU memory and models during shutdown:
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    model = load_model()
+    yield
+    del model
+    torch.cuda.empty_cache()
+Troubleshooting
+502 errors during scaling
+
+Add or increase response_grace_period in cerebrium.toml
+
+Shutdown code never runs
+
+Verify exec is in your entrypoint
+Test locally with Ctrl+C - you should see shutdown logs
+Check for process wrappers blocking signals (dumb-init, etc.)
+
+Containers not terminating
+
+Ensure your shutdown code completes within response_grace_period
+Verify no infinite loops in cleanup logic
+
+<Note>
+Custom runtimes require three components: `response_grace_period` configuration + SIGTERM handling code + `exec` in entrypoint
+</Note>
+```
+This follows Modal's structure (intro → preparation → implementation → best practices) while addressing every issue BitHuman faced: missing response_grace_period, missing exec, FastAPI lifespan pattern, and the debugging journey they went through.

--- a/cerebrium/scaling/graceful-termination.mdx
+++ b/cerebrium/scaling/graceful-termination.mdx
@@ -1,36 +1,44 @@
+---
 title: "Graceful Termination"
-description: "Prevent 502 errors during instance shutdown"
+description: "Prevent 502 errors by handling SIGTERM signals during instance shutdown"
 ---
 
-Cerebrium instances are subject to termination during scaling events and redeployments. Without proper configuration, active requests fail with 502 errors when instances are killed mid-execution.
+# Graceful Termination
 
-Instance terminations are common during normal operations. Applications with long-running tasks (model inference, video processing, etc.) must handle termination gracefully, as the likelihood of interruption increases with task duration.
+**Cerebrium sends SIGTERM signals when scaling down instances.** Without proper handling, active requests fail with 502 errors. This requires both platform configuration and application-level code changes.
 
-## Preparing for Termination
+## How Instance Termination Works
 
-Configure `response_grace_period` in `cerebrium.toml`:
+When Cerebrium needs to terminate an instance (during scale-down or redeployment):
+
+1. **Stops routing new requests** to the instance  
+2. **Sends SIGTERM signal** to your container  
+3. **Waits** for `response_grace_period` seconds (if configured)  
+4. **Sends SIGKILL** if the instance hasn't stopped  
+
+**Without `response_grace_period` configured, Cerebrium force-kills instances immediately, causing 502 errors.**
+
+## Required: Configure Grace Period
+
+Set `response_grace_period` in `cerebrium.toml` to give your application time to finish active requests:
+
 ```toml
 [cerebrium.scaling]
-response_grace_period = 300  # Seconds before force-kill
+response_grace_period = 300  # Seconds to wait before SIGKILL
 
-<Warning>
-Without this configuration, Cerebrium force-kills instances immediately, causing 502 errors.
-</Warning>
-When termination occurs, Cerebrium:
+<Warning> Missing this configuration is the most common cause of 502 errors during scaling. Set this to **1.5× your longest expected request duration**. </Warning>
 
-Stops routing new requests
-Sends SIGTERM signal
-Waits response_grace_period seconds
-Sends SIGKILL
+Runtime-Specific Requirements
 
-Set to 1.5x your longest expected request duration.
-Runtime-Specific Handling
-Cortex Runtime (Default): Automatic - SIGTERM is captured and requests complete before termination.
-Custom Runtime: You must implement SIGTERM handling in your application code.
+Cortex Runtime (Default):
+SIGTERM is handled automatically. Just configure response_grace_period — no code changes needed.
 
-Custom Runtime Implementation
-FastAPI
-Implement the lifespan pattern to track active requests:
+Custom Runtime (FastAPI, Flask, etc.):
+You must implement SIGTERM handling in your application and configure response_grace_period. Both are required.
+
+FastAPI Implementation
+
+For custom runtimes using FastAPI, implement the lifespan pattern to respond to SIGTERM:
 
 from fastapi import FastAPI, HTTPException
 from contextlib import asynccontextmanager
@@ -42,11 +50,13 @@ lock = asyncio.Lock()
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    yield
+    yield  # Application startup complete
     
+    # Shutdown: runs when Cerebrium sends SIGTERM
     global shutting_down
     shutting_down = True
     
+    # Wait for active requests to complete
     while active_requests > 0:
         await asyncio.sleep(1)
 
@@ -66,44 +76,75 @@ async def track_requests(request, call_next):
         async with lock:
             active_requests -= 1
 
-Critical: Entrypoint Configuration
-Your entrypoint must use exec to ensure SIGTERM reaches the application:
-dockerfileENTRYPOINT ["exec", "fastapi", "run", "app.py", "--port", "8000"]
+Critical: Use exec in Entrypoint
 
-Or in bash scripts:
-bashexec fastapi run app.py --port ${PORT:-8000}
-Without exec, SIGTERM is sent to the shell (PID 1) instead of your application, and graceful shutdown never executes.
+Your entrypoint must use exec or SIGTERM won't reach your application.
 
-Best Practices
+Dockerfile example:
 
-Checkpoint long operations - Save progress frequently for tasks exceeding the grace period
-Make operations idempotent - Ensure interrupted tasks can safely retry
-Explicit resource cleanup - Release GPU memory and models during shutdown:
+ENTRYPOINT ["exec", "fastapi", "run", "app.py", "--port", "8000"]
+
+Bash script example:
+
+exec fastapi run app.py --port ${PORT:-8000}
+
+Without exec, SIGTERM is sent to the bash script (PID 1) instead of FastAPI,
+so your shutdown code never runs and Cerebrium force-kills the container after the grace period.
+
+GPU Resource Cleanup
+
+For GPU applications, explicitly release resources during shutdown:
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     model = load_model()
     yield
+    # Cleanup when SIGTERM received
     del model
     torch.cuda.empty_cache()
+
 Troubleshooting
-502 errors during scaling
 
-Add or increase response_grace_period in cerebrium.toml
+502 errors during scaling events
 
-Shutdown code never runs
+Cause: response_grace_period not configured or too short
 
-Verify exec is in your entrypoint
-Test locally with Ctrl+C - you should see shutdown logs
-Check for process wrappers blocking signals (dumb-init, etc.)
+Solution: Add to cerebrium.toml and set to 1.5× your longest request duration
 
-Containers not terminating
+Shutdown code never executes
 
-Ensure your shutdown code completes within response_grace_period
-Verify no infinite loops in cleanup logic
+Cause: SIGTERM not reaching your application
 
-<Note>
-Custom runtimes require three components: `response_grace_period` configuration + SIGTERM handling code + `exec` in entrypoint
+Solution:
+
+Add exec to your entrypoint command
+
+Test locally: Run your app and press Ctrl+C — you should see shutdown logs
+
+Remove unnecessary process wrappers (dumb-init, etc.) that may block signals
+
+Containers don't terminate automatically
+
+Cause: Shutdown code takes longer than response_grace_period or has infinite loops
+
+Solution: Ensure cleanup completes within the grace period and verify no blocking operations
+
+Testing Locally
+
+Before deploying, verify SIGTERM handling works:
+
+# Start your application
+python -m your_app
+
+# In another terminal, send SIGTERM
+kill -TERM $(pgrep -f your_app)
+
+# You should see graceful shutdown logs
+
+<Note> Custom runtimes require three components: - `response_grace_period` configuration - SIGTERM handling code - `exec` in entrypoint
+
+Missing any of these causes 502 errors.
 </Note>
-```
-This follows Modal's structure (intro → preparation → implementation → best practices) while addressing every issue BitHuman faced: missing response_grace_period, missing exec, FastAPI lifespan pattern, and the debugging journey they went through.
+
+
+


### PR DESCRIPTION
## Add graceful termination documentation

Adds comprehensive documentation for handling instance termination to prevent 502 errors during scaling events.

### What this addresses

This documentation resolves a critical gap identified through customer support cases where users experienced persistent 502 errors during scaling. The root cause was missing `response_grace_period` configuration and improper SIGTERM handling in custom runtimes.

### Changes

- **New page**: `cerebrium/scaling/graceful-termination.mdx`
- Explains Cerebrium's SIGTERM-based termination flow
- Documents required `response_grace_period` configuration
- Provides FastAPI implementation with proper request tracking
- Highlights critical `exec` requirement for entrypoints
- Includes troubleshooting for common issues (502 errors, shutdown code not running, containers not terminating)

### Key improvements

- Front-loads SIGTERM explanation (previously buried in scaling docs)
- Clarifies difference between Cortex (automatic) and Custom runtime (manual) handling
- Provides complete working code examples based on real customer implementations
- Connects FastAPI's lifespan pattern to Cerebrium's platform requirements

### Reference

Based on extended customer support thread with BitHuman team experiencing 502 errors that were resolved by adding `response_grace_period` configuration and fixing entrypoint to use `exec`.