### PR TITLE
chore: remove provider and region from inline TOML examples

### DIFF
--- a/migrations/replicate.mdx
+++ b/migrations/replicate.mdx
@@ -33,8 +33,6 @@ shell_commands = [
 ]
 
 [cerebrium.hardware]
-region = "us-east-1"
-provider = "aws"
 compute = "AMPERE_A10"
 cpu = 2
 memory = 12.0

--- a/partner-services/deepgram.mdx
+++ b/partner-services/deepgram.mdx
@@ -280,7 +280,6 @@ disable_auth = true
 
 [cerebrium.hardware]
 cpu = 4
-region = "us-east-1"
 memory = 32
 compute = "AMPERE_A10"
 gpu_count = 1

--- a/partner-services/rime.mdx
+++ b/partner-services/rime.mdx
@@ -36,7 +36,6 @@ cpu = 4
 memory = 30
 compute = "AMPERE_A10"
 gpu_count = 1
-region = "us-east-1"
 
 [cerebrium.scaling]
 min_replicas = 1

--- a/scaling/graceful-termination.mdx
+++ b/scaling/graceful-termination.mdx
@@ -135,8 +135,6 @@ cpu = 1
 memory = 1.0
 compute = "CPU"
 gpu_count = 0
-provider = "aws"
-region = "us-east-1"
 
 [cerebrium.scaling]
 min_replicas = 0

--- a/toml-reference/toml-reference.mdx
+++ b/toml-reference/toml-reference.mdx
@@ -110,14 +110,12 @@ The `[cerebrium.runtime.custom]` section configures custom web servers and runti
 
 The `[cerebrium.hardware]` section defines compute resources.
 
-| Option    | Type    | Default     | Description                          |
-| --------- | ------- | ----------- | ------------------------------------ |
-| cpu       | float   | required    | Number of CPU cores                  |
-| memory    | float   | required    | Memory allocation in GB              |
-| compute   | string  | "CPU"       | Compute type (CPU, AMPERE_A10, etc.) |
-| gpu_count | integer | 0           | Number of GPUs                       |
-| provider  | string  | "aws"       | Cloud provider                       |
-| region    | string  | "us-east-1" | Deployment region                    |
+| Option    | Type    | Default  | Description                          |
+| --------- | ------- | -------- | ------------------------------------ |
+| cpu       | float   | required | Number of CPU cores                  |
+| memory    | float   | required | Memory allocation in GB              |
+| compute   | string  | "CPU"    | Compute type (CPU, AMPERE_A10, etc.) |
+| gpu_count | integer | 0        | Number of GPUs                       |
 
 <Warning>
   Memory refers to RAM, not GPU VRAM. Ensure sufficient memory for your
@@ -233,8 +231,6 @@ cpu = 4
 memory = 16.0
 compute = "AMPERE_A10"
 gpu_count = 1
-provider = "aws"
-region = "us-east-1"
 
 [cerebrium.scaling]
 min_replicas = 0

--- a/toml-reference/toml-reference.mdx
+++ b/toml-reference/toml-reference.mdx
@@ -110,12 +110,14 @@ The `[cerebrium.runtime.custom]` section configures custom web servers and runti
 
 The `[cerebrium.hardware]` section defines compute resources.
 
-| Option    | Type    | Default  | Description                          |
-| --------- | ------- | -------- | ------------------------------------ |
-| cpu       | float   | required | Number of CPU cores                  |
-| memory    | float   | required | Memory allocation in GB              |
-| compute   | string  | "CPU"    | Compute type (CPU, AMPERE_A10, etc.) |
-| gpu_count | integer | 0        | Number of GPUs                       |
+| Option    | Type    | Default     | Description                          |
+| --------- | ------- | ----------- | ------------------------------------ |
+| cpu       | float   | required    | Number of CPU cores                  |
+| memory    | float   | required    | Memory allocation in GB              |
+| compute   | string  | "CPU"       | Compute type (CPU, AMPERE_A10, etc.) |
+| gpu_count | integer | 0           | Number of GPUs                       |
+| provider  | string  | "aws"       | Cloud provider                       |
+| region    | string  | "us-east-1" | Deployment region                    |
 
 <Warning>
   Memory refers to RAM, not GPU VRAM. Ensure sufficient memory for your
@@ -231,6 +233,8 @@ cpu = 4
 memory = 16.0
 compute = "AMPERE_A10"
 gpu_count = 1
+provider = "aws"
+region = "us-east-1"
 
 [cerebrium.scaling]
 min_replicas = 0

--- a/v4/examples/aiVoiceAgents.mdx
+++ b/v4/examples/aiVoiceAgents.mdx
@@ -176,8 +176,6 @@ include = ["./*", "main.py", "cerebrium.toml"]
 exclude = ["./example_exclude"]
 
 [cerebrium.hardware]
-region = "us-east-1"
-provider = "aws"
 compute = "CPU"
 cpu = 6
 memory = 18.0

--- a/v4/examples/deploy-an-llm-with-tensorrtllm-tritonserver.mdx
+++ b/v4/examples/deploy-an-llm-with-tensorrtllm-tritonserver.mdx
@@ -401,8 +401,6 @@ cpu = 4.0
 memory = 40.0
 compute = "AMPERE_A10"
 gpu_count = 1
-provider = "aws"
-region = "us-east-1"
 
 [cerebrium.scaling]
 min_replicas = 0

--- a/v4/examples/gpt-oss.mdx
+++ b/v4/examples/gpt-oss.mdx
@@ -46,8 +46,6 @@ pre_build_commands = [
 cpu = 8.0
 memory = 18.0
 compute = "HOPPER_H100"
-provider = "aws"
-region = "us-east-1"
 
 [cerebrium.scaling]
 min_replicas = 0

--- a/v4/examples/high-throughput-embeddings.mdx
+++ b/v4/examples/high-throughput-embeddings.mdx
@@ -51,7 +51,6 @@ Autoscaling criteria vary by hardware type and model selection. Define them in t
 cpu = 6.0
 memory = 12.0
 compute = "AMPERE_A10"
-region = "us-east-1"
 
 [cerebrium.scaling]
 min_replicas = 0

--- a/v4/examples/mistral-vllm.mdx
+++ b/v4/examples/mistral-vllm.mdx
@@ -121,8 +121,6 @@ exclude = ["./example_exclude"]
 docker_base_image_url = "nvidia/cuda:12.1.1-runtime-ubuntu22.04"
 
 [cerebrium.hardware]
-region = "us-east-1"
-provider = "aws"
 compute = "AMPERE_A10"
 cpu = 2
 memory = 16.0

--- a/v4/examples/realtime-voice-agents.mdx
+++ b/v4/examples/realtime-voice-agents.mdx
@@ -181,8 +181,6 @@ include = ["./*", "main.py", "cerebrium.toml"]
 exclude = ["./example_exclude"]
 
 [cerebrium.hardware]
-region = "us-east-1"
-provider = "aws"
 compute = "CPU"
 cpu = 6
 memory = 12.0

--- a/v4/examples/sdxl.mdx
+++ b/v4/examples/sdxl.mdx
@@ -34,8 +34,6 @@ include = ["./*", "main.py", "cerebrium.toml"]
 exclude = ["./.*", "./__*"]
 
 [cerebrium.hardware]
-region = "us-east-1"
-provider = "aws"
 compute = "AMPERE_A10"
 cpu = 2
 memory = 16.0

--- a/v4/examples/streaming-falcon-7B.mdx
+++ b/v4/examples/streaming-falcon-7B.mdx
@@ -146,8 +146,6 @@ exclude = ["./example_exclude"]
 docker_base_image_url = "nvidia/cuda:12.1.1-runtime-ubuntu22.04"
 
 [cerebrium.hardware]
-region = "us-east-1"
-provider = "aws"
 compute = "AMPERE_A10"
 cpu = 2
 memory = 16.0

--- a/v4/examples/transcribe-whisper.mdx
+++ b/v4/examples/transcribe-whisper.mdx
@@ -114,8 +114,6 @@ exclude = ["./example_exclude"]
 docker_base_image_url = "nvidia/cuda:12.1.1-runtime-ubuntu22.04"
 
 [cerebrium.hardware]
-region = "us-east-1"
-provider = "aws"
 compute = "AMPERE_A10"
 cpu = 3
 memory = 12.0

--- a/v4/examples/twilio-voice-agent.mdx
+++ b/v4/examples/twilio-voice-agent.mdx
@@ -264,8 +264,6 @@ Update `cerebrium.toml` with the following:
 
 ```
 [cerebrium.hardware]
-region = "us-east-1"
-provider = "aws"
 compute = "CPU"
 cpu = 10
 memory = 8.0


### PR DESCRIPTION
## Summary
Strip `provider` and `region` lines from inline `cerebrium.toml` snippets across example pages, migration guides, and partner-services docs (13 files).

The `toml-reference/toml-reference.mdx` page is intentionally left untouched — it remains the canonical reference and continues to document both keys.

## Test plan
- [ ] Local Mintlify preview renders cleanly (no orphan blank lines in stripped TOML blocks)
- [ ] Spot-check a few of the touched example pages render the hardware section correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)