### PR TITLE
docs: document region as an array of strings with locale keywords

### DIFF
--- a/deployments/multi-region-deployment.mdx
+++ b/deployments/multi-region-deployment.mdx
@@ -90,17 +90,17 @@ region = ["us-east-1", "eu-west-2"]
 
 In addition to explicit region names, `region` accepts shorthand keywords that expand to a group of regions. This is useful when you want to deploy across an entire locale or to every available region without listing them individually.
 
-| Keyword       | Expands to                                |
-| ------------- | ----------------------------------------- |
-| `*`           | All available regions                     |
-| `us`          | `us-east-1`                               |
-| `us-east`     | `us-east-1`                               |
-| `eu`          | `eu-west-2`, `eu-north-1`                 |
-| `eu-west`     | `eu-west-2`                               |
-| `eu-north`    | `eu-north-1`                              |
-| `uk`          | `eu-west-2`                               |
-| `ap`          | `ap-south-1`                              |
-| `ap-south`    | `ap-south-1`                              |
+| Keyword    | Expands to                |
+| ---------- | ------------------------- |
+| `*`        | All available regions     |
+| `us`       | `us-east-1`               |
+| `us-east`  | `us-east-1`               |
+| `eu`       | `eu-west-2`, `eu-north-1` |
+| `eu-west`  | `eu-west-2`               |
+| `eu-north` | `eu-north-1`              |
+| `uk`       | `eu-west-2`               |
+| `ap`       | `ap-south-1`              |
+| `ap-south` | `ap-south-1`              |
 
 Keywords and explicit region names can be mixed in the same array:
 

--- a/deployments/multi-region-deployment.mdx
+++ b/deployments/multi-region-deployment.mdx
@@ -70,16 +70,45 @@ cerebrium download results.json -r eu-north-1
 
 ## App Deployment
 
-Set the deployment region using the `region` parameter in the `[cerebrium.hardware]` section of `cerebrium.toml`:
+Set the deployment regions using the `region` parameter in the `[cerebrium.hardware]` section of `cerebrium.toml`. The value is an array of strings — apps deploy to every region in the list:
 
 ```toml
 [cerebrium.hardware]
-region = "us-east-1"
-provider = "aws"
+region = ["us-east-1"]
 compute = "AMPERE_A10"
 cpu = 2
 memory = 8.0
 ```
+
+To deploy to several regions at once, list each one explicitly:
+
+```toml
+region = ["us-east-1", "eu-west-2"]
+```
+
+### Region Keywords
+
+In addition to explicit region names, `region` accepts shorthand keywords that expand to a group of regions. This is useful when you want to deploy across an entire locale or to every available region without listing them individually.
+
+| Keyword       | Expands to                                |
+| ------------- | ----------------------------------------- |
+| `*`           | All available regions                     |
+| `us`          | `us-east-1`                               |
+| `us-east`     | `us-east-1`                               |
+| `eu`          | `eu-west-2`, `eu-north-1`                 |
+| `eu-west`     | `eu-west-2`                               |
+| `eu-north`    | `eu-north-1`                              |
+| `uk`          | `eu-west-2`                               |
+| `ap`          | `ap-south-1`                              |
+| `ap-south`    | `ap-south-1`                              |
+
+Keywords and explicit region names can be mixed in the same array:
+
+```toml
+region = ["us", "eu-west-2"]
+```
+
+If `region` is omitted, apps deploy to all available regions (`["*"]`).
 
 ## Pricing
 

--- a/toml-reference/toml-reference.mdx
+++ b/toml-reference/toml-reference.mdx
@@ -110,14 +110,14 @@ The `[cerebrium.runtime.custom]` section configures custom web servers and runti
 
 The `[cerebrium.hardware]` section defines compute resources.
 
-| Option    | Type    | Default     | Description                          |
-| --------- | ------- | ----------- | ------------------------------------ |
-| cpu       | float   | required    | Number of CPU cores                  |
-| memory    | float   | required    | Memory allocation in GB              |
-| compute   | string  | "CPU"       | Compute type (CPU, AMPERE_A10, etc.) |
-| gpu_count | integer | 0           | Number of GPUs                       |
-| provider  | string  | "aws"       | Cloud provider                       |
-| region    | string  | "us-east-1" | Deployment region                    |
+| Option    | Type            | Default  | Description                                                                                        |
+| --------- | --------------- | -------- | -------------------------------------------------------------------------------------------------- |
+| cpu       | float           | required | Number of CPU cores                                                                                |
+| memory    | float           | required | Memory allocation in GB                                                                            |
+| compute   | string          | "CPU"    | Compute type (CPU, AMPERE_A10, etc.)                                                               |
+| gpu_count | integer         | 0        | Number of GPUs                                                                                     |
+| provider  | string          | "aws"    | Cloud provider                                                                                     |
+| region    | array of string | `["*"]`  | Regions to deploy to. Accepts explicit region names (e.g. `"us-east-1"`) and keywords like `"eu"`. |
 
 <Warning>
   Memory refers to RAM, not GPU VRAM. Ensure sufficient memory for your


### PR DESCRIPTION
## Summary
- `deployments/multi-region-deployment.mdx`: update the `cerebrium.toml` example to show `region` as a TOML array, add a "Region Keywords" section listing `*`, `us`, `eu`, `ap`, `uk`, and the narrow variants we currently support, with a mixed-array example.
- `toml-reference/toml-reference.mdx`: update the existing `region` row in the hardware-options table from `string` / `"us-east-1"` to `array of string` / `["*"]`. The `provider` row is unchanged.

Stacked on #277. Draft until that PR merges.

Region keywords listed are filtered to those that resolve to at least one currently-available region — we don't list keywords that have no clusters behind them yet (e.g. `us-west`, `jp`, `ca`, etc.).

## Test plan
- [ ] Local Mintlify preview renders both tables correctly
- [ ] Spot-check the keyword table in `multi-region-deployment.mdx` lines up with the regions listed in the "Available Regions" section above it

🤖 Generated with [Claude Code](https://claude.com/claude-code)