### PR TITLE
Use the global endpoint URL across all docs

### DIFF
--- a/container-images/custom-web-servers.mdx
+++ b/container-images/custom-web-servers.mdx
@@ -53,7 +53,7 @@ The configuration requires three key parameters:
   For ASGI applications like FastAPI, include the appropriate server package
   (like `uvicorn`) in your dependencies. After deployment, your endpoints become
   available at
-  `https://api.aws.us-east-1.cerebrium.ai/v4/[project-id]/[app-name]/your/endpoint`.
+  `https://api.cerebrium.ai/v4/p-xxxxxxxx/[app-name]/your/endpoint`.
 </Info>
 
 The [FastAPI Server Example](https://github.com/CerebriumAI/examples) provides a complete implementation.

--- a/container-images/defining-container-images.mdx
+++ b/container-images/defining-container-images.mdx
@@ -273,7 +273,7 @@ vllm = "latest"
 - Code is mounted in `/cortex` - adjust paths accordingly.
 - The port in your entrypoint must match the `port` parameter.
 - Install any required server packages (uvicorn, gunicorn, etc.) via pip dependencies.
-- All endpoints will be available at `https://api.cerebrium.ai/v4/{project-id}/{app-name}/your/endpoint`.
+- All endpoints will be available at `https://api.cerebrium.ai/v4/p-xxxxxxxx/{app-name}/your/endpoint`.
 
 Deploy with `cerebrium deploy -y` - the system automatically detects custom runtime configuration.
 

--- a/deployments/multi-region-deployment.mdx
+++ b/deployments/multi-region-deployment.mdx
@@ -98,7 +98,7 @@ GPU availability and pricing vary across regions due to infrastructure constrain
 | BLACKWELL_RTX6000 | ❌      | ✅         | ❌      | ❌       | ❌       |
 | AMPERE_A100_80GB  | ✅      | ❌         | ✅      | ✅       | ✅       |
 | AMPERE_A100_40GB  | ✅      | ❌         | ✅      | ✅       | ✅       |
-| ADA_L40S          | ✅      | ❌         | ❌      | ✅       | ❌       |
+| ADA_L40           | ✅      | ❌         | ❌      | ✅       | ❌       |
 | ADA_L4            | ✅      | ❌         | ✅      | ✅       | ✅       |
 | AMPERE_A10        | ✅      | ❌         | ✅      | ✅       | ✅       |
 | TURING_T4         | ✅      | ❌         | ✅      | ✅       | ✅       |

--- a/endpoints/async.mdx
+++ b/endpoints/async.mdx
@@ -8,7 +8,7 @@ Some apps require asynchronous "fire-and-forget" execution. In this model, Cereb
 Enable async execution by adding the `async=true` query parameter to the request:
 
 ```bash
-curl -X POST https://api.aws.us-east-1.cerebrium.ai/v4/<YOUR-PROJECT-ID>/<YOUR-APP>/run?async=true'\
+curl -X POST https://api.cerebrium.ai/v4/p-xxxxxxxx/<YOUR-APP>/run?async=true'\
        -H 'Content-Type: application/json'\
        -H 'Authorization: Bearer <YOUR-JWT-TOKEN>\
        --data '{"param": "hello world"}'
@@ -38,7 +38,7 @@ Returning a response while the application is still processing causes Cerebrium 
 Because async calls do not return a response to the caller, the function must export any relevant data itself. Combine async execution with a `webhookEndpoint` to have Cerebrium automatically forward the function's response body:
 
 ```bash
-curl -X POST <https://api.aws.us-east-1.cerebrium.ai/v4/><YOUR-PROJECT-ID>/<YOUR-APP>/run?async=true&webhookEndpoint=https%3A%2F%2Fwebhook.site%2F'\
+curl -X POST <https://api.cerebrium.ai/v4/>p-xxxxxxxx/<YOUR-APP>/run?async=true&webhookEndpoint=https%3A%2F%2Fwebhook.site%2F'\
  -H 'Content-Type: application/json'\
  -H 'Authorization: Bearer <YOUR-JWT-TOKEN>\
  --data '{"param": "hello world"}'

--- a/endpoints/inference-api.mdx
+++ b/endpoints/inference-api.mdx
@@ -10,13 +10,19 @@ All functions on Cerebrium are accessible via authenticated POST requests by def
 The POST request follows the structure below, where `{function}` is the name of the function to invoke. In this example, `predict()` from `main.py` is called.
 
 ```bash
-curl --location --request POST 'https://api.aws.us-east-1.cerebrium.ai/v4/p-xxxxx/{app-name}/{function}' \
+curl --location --request POST 'https://api.cerebrium.ai/v4/p-xxxxxxxx/{app-name}/{function}' \
 --header 'Authorization: Bearer <JWT_TOKEN>' \
 --header 'Content-Type: application/json' \
 --data '{
   "function_param": "data"
 }'
 ```
+
+<Note>
+  Regioned hostnames such as `https://api.aws.us-east-1.cerebrium.ai` continue
+  to work. Requests to these hostnames are proxied to the global router, which
+  can add latency. Use `https://api.cerebrium.ai` for the lowest-latency path.
+</Note>
 
 ## Response format
 

--- a/endpoints/openai-compatible-endpoints.mdx
+++ b/endpoints/openai-compatible-endpoints.mdx
@@ -51,7 +51,7 @@ from openai import OpenAI
 
 client = OpenAI(
     # This is the default and can be omitted
-    base_url="https://api.aws.us-east-1.cerebrium.ai/v4/p-xxxxx/1-openai-compatible-endpoint/run", ##This is the name of the function you are calling
+    base_url="https://api.cerebrium.ai/v4/p-xxxxxxxx/1-openai-compatible-endpoint/run", ##This is the name of the function you are calling
     api_key="<CEREBRIUM_JWT_TOKEN>",
 )
 

--- a/endpoints/streaming.mdx
+++ b/endpoints/streaming.mdx
@@ -22,7 +22,7 @@ def run(upper_range: int):
 Deploy this snippet and call the endpoint. SSE events appear progressively, one per second:
 
 ```bash
-curl -X POST https://api.aws.us-east-1.cerebrium.ai/v4/<YOUR-PROJECT-ID>/2-streaming-endpoint/run \
+curl -X POST https://api.cerebrium.ai/v4/p-xxxxxxxx/2-streaming-endpoint/run \
        -H 'Content-Type: application/json'\
        -H 'Accept: text/event-stream\
        -H 'Authorization: Bearer <YOUR-JWT-TOKEN>\

--- a/endpoints/webhook.mdx
+++ b/endpoints/webhook.mdx
@@ -6,7 +6,7 @@ description: "Forward responses to a specified webhook"
 Forward function response data to an external endpoint via POST by adding the `webhookEndpoint` query parameter to any API call:
 
 ```bash
-curl -X POST https://api.aws.us-east-1.cerebrium.ai/v4/<YOUR-PROJECT-ID>/<YOUR-APP>/run?webhookEndpoint=https%3A%2F%2Fwebhook.site%2F'\
+curl -X POST https://api.cerebrium.ai/v4/p-xxxxxxxx/<YOUR-APP>/run?webhookEndpoint=https%3A%2F%2Fwebhook.site%2F'\
        -H 'Content-Type: application/json'\
        -H 'Authorization: Bearer <YOUR-JWT-TOKEN>\
        --data '{"param": "hello world"}'

--- a/endpoints/websockets.mdx
+++ b/endpoints/websockets.mdx
@@ -34,7 +34,7 @@ Fields:
 Test the WebSocket endpoint using websocat, a command-line WebSocket client:
 
 ```bash
-websocat wss://api.aws.us-east-1.cerebrium.ai/v4/<your-project-id>/<your-app-name>/<your-websocket-function-name>
+websocat wss://api.cerebrium.ai/v4/p-xxxxxxxx/<your-app-name>/<your-websocket-function-name>
 ```
 
 ## Implementing the WebSocket Endpoint
@@ -61,7 +61,7 @@ Client-side Implementation: Handle the WebSocket connection properly on the clie
 ```javascript
 // Example using JavaScript in a browser
 const socket = new WebSocket(
-  "wss://api.aws.us-east-1.cerebrium.ai/v4/<your-project-id>/<your-app-name>/<your-websocket-function-name>",
+  "wss://api.cerebrium.ai/v4/p-xxxxxxxx/<your-app-name>/<your-websocket-function-name>",
 );
 
 socket.onopen = function (event) {

--- a/getting-started/introduction.mdx
+++ b/getting-started/introduction.mdx
@@ -126,7 +126,7 @@ This turns the function into a persistent [REST endpoint](/endpoints/inference-a
 Once deployed, the app is callable at a POST endpoint:
 
 ```text
-https://api.aws.us-east-1.cerebrium.ai/v4/{project-id}/{app-name}/{function-name}
+https://api.cerebrium.ai/v4/p-xxxxxxxx/{app-name}/{function-name}
 ```
 
 ### 6. What to do next

--- a/integrations/vercel.mdx
+++ b/integrations/vercel.mdx
@@ -42,19 +42,16 @@ See the [Mistral 7B with vLLM example](/v4/examples/mistral-vllm) for deploying 
 After deploying the app, the output includes the endpoint URL. Call it from a Vercel project:
 
 ```javascript
-fetch(
-  "https://api.aws.us-east-1.cerebrium.ai/v4/p-<YOUR PROJECT ID>/mistral-vllm/predict",
-  {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${process.env.CEREBRIUM_JWT}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      prompt: "What is the capital city of France?",
-    }),
+fetch("https://api.cerebrium.ai/v4/p-xxxxxxxx/mistral-vllm/predict", {
+  method: "POST",
+  headers: {
+    Authorization: `Bearer ${process.env.CEREBRIUM_JWT}`,
+    "Content-Type": "application/json",
   },
-)
+  body: JSON.stringify({
+    prompt: "What is the capital city of France?",
+  }),
+})
   .then((response) => response.json())
   .then((data) => console.log(data))
   .catch((error) => console.error("Error:", error));

--- a/migrations/hugging-face.mdx
+++ b/migrations/hugging-face.mdx
@@ -186,7 +186,7 @@ Once deployed, you can use your model as follows:
 import requests
 import json
 
-url = "https://api.aws.us-east-1.cerebrium.ai/v4/[PROJECT_NAME]/llama-8b-vllm/run"
+url = "https://api.cerebrium.ai/v4/p-xxxxxxxx/llama-8b-vllm/run"
 
 payload = json.dumps({"prompt": "tell me about yourself"})
 

--- a/migrations/mystic.mdx
+++ b/migrations/mystic.mdx
@@ -273,7 +273,7 @@ cerebrium deploy
 Once your app is deployed, you can make requests to your model using the example cURL request below:
 
 ```bash
-curl --location 'https://api.aws.us-east-1.cerebrium.ai/v4/p-<YOUR PROJECT ID>/stable-diffusion/predict' \
+curl --location 'https://api.cerebrium.ai/v4/p-xxxxxxxx/stable-diffusion/predict' \
 --header 'Content-Type: application/json' \
 --header 'Authorization: Bearer <YOUR TOKEN HERE>' \
 --data '{

--- a/partner-services/deepgram.mdx
+++ b/partner-services/deepgram.mdx
@@ -309,7 +309,7 @@ wget https://dpgr.am/bueller.wav
 9. Call the Deepgram endpoint with appropriate parameters:
 
 ```curl
-curl -X POST --data-binary @bueller.wav "https://api.aws.us-east-1.cerebrium.ai/v4/p-xxxxxx/deepgram/v1/listen?model=nova-3&smart_format=true"
+curl -X POST --data-binary @bueller.wav "https://api.cerebrium.ai/v4/p-xxxxxxxx/deepgram/v1/listen?model=nova-3&smart_format=true"
 ```
 
 Parameters accepted by the Deepgram service can be found in the [speech-to-text API reference](https://developers.deepgram.com/reference/speech-to-text-api/listen-streaming).

--- a/partner-services/rime.mdx
+++ b/partner-services/rime.mdx
@@ -65,7 +65,7 @@ App Dashboard: https://dashboard.cerebrium.ai/projects/p-xxxxxxxx/apps/p-xxxxxxx
 5. Send requests to the <b>HTTP</b> Rime service using the deployment URL from the output:
 
 ```
-curl --location 'https://api.aws.us-east-1.cerebrium.ai/v4/p-xxxxxxxx/rime' \
+curl --location 'https://api.cerebrium.ai/v4/p-xxxxxxxx/rime' \
 --header 'Authorization: Bearer <RIME_API_KEY>' \
 --header 'Content-Type: application/json' \
 --header 'Accept: audio/pcm' \
@@ -79,7 +79,7 @@ curl --location 'https://api.aws.us-east-1.cerebrium.ai/v4/p-xxxxxxxx/rime' \
 For <b>Websockets</b>, send the following
 
 ```
-wss://api.aws.us-east-1.cerebrium.ai/v4/p-xxxxxx/rime/ws2?audioFormat=mp3&speaker=cove&modelId=mistv2&phonemizeBetweenBrackets=true
+wss://api.cerebrium.ai/v4/p-xxxxxxxx/rime/ws2?audioFormat=mp3&speaker=cove&modelId=mistv2&phonemizeBetweenBrackets=true
 Authorization Bearer <RIME_API_KEY>
 
 #With a message like:

--- a/toml-reference/toml-reference.mdx
+++ b/toml-reference/toml-reference.mdx
@@ -102,8 +102,8 @@ The `[cerebrium.runtime.custom]` section configures custom web servers and runti
 
 <Info>
   The port specified in entrypoint must match the port parameter. All endpoints
-  will be available at `https://api.aws.us-east-1.cerebrium.ai/v4/{project - id}
-  /{app - name}/your/endpoint`
+  will be available at
+  `https://api.cerebrium.ai/v4/p-xxxxxxxx/your-app-name/your/endpoint`
 </Info>
 
 ## Hardware Configuration

--- a/v4/examples/aiVoiceAgents.mdx
+++ b/v4/examples/aiVoiceAgents.mdx
@@ -488,7 +488,7 @@ A public fork of the PipeCat frontend demonstrates this application. Clone the r
 Follow the instructions in the README.md and then populate the following variables in your .env.development.local
 
 ```
-VITE_SERVER_URL=https://api.aws.us-east-1.cerebrium.ai/v4/p-xxxxx/<APP_NAME> #This is the base url. Do not include the function names
+VITE_SERVER_URL=https://api.cerebrium.ai/v4/p-xxxxxxxx/<APP_NAME> #This is the base url. Do not include the function names
 VITE_SERVER_AUTH= #This is the JWT token you can get from the API Keys section of your Cerebrium Dashboard.
 ```
 

--- a/v4/examples/asgi-gradio-interface.mdx
+++ b/v4/examples/asgi-gradio-interface.mdx
@@ -210,7 +210,7 @@ class GradioServer:
         interface.launch(
             server_name=self.host,
             server_port=self.port,
-            root_path=f"https://api.aws.us-east-1.cerebrium.ai/v4/{os.getenv('PROJECT_ID')}/{os.getenv('APP_NAME')}/",
+            root_path=f"https://api.cerebrium.ai/v4/{os.getenv('PROJECT_ID')}/{os.getenv('APP_NAME')}/",
             quiet=True
         )
 
@@ -350,7 +350,7 @@ class GradioServer:
         interface.launch(
             server_name=self.host,
             server_port=self.port,
-            root_path=f"https://api.aws.us-east-1.cerebrium.ai/v4/{os.getenv('PROJECT_ID')}/{os.getenv('APP_NAME')}/",
+            root_path=f"https://api.cerebrium.ai/v4/{os.getenv('PROJECT_ID')}/{os.getenv('APP_NAME')}/",
             quiet=True
         )
 
@@ -445,7 +445,7 @@ cerebrium deploy -y
 Once deployed, navigate to the following URL in your browser:
 
 ```
-https://api.aws.us-east-1.cerebrium.ai/v4/p-<YOUR_PROJECT_ID>/2-gradio-interface/
+https://api.cerebrium.ai/v4/p-xxxxxxxx/2-gradio-interface/
 ```
 
 The Gradio chat interface appears at this URL.

--- a/v4/examples/comfyUI.mdx
+++ b/v4/examples/comfyUI.mdx
@@ -343,7 +343,7 @@ Deploy the application: `cerebrium deploy`
 After successful deployment, make a request to the endpoint with the following JSON payload:
 
 ```curl
-curl --location 'https://api.aws.us-east-1.cerebrium.ai/v4/p-xxxx/1-comfyui/run' \
+curl --location 'https://api.cerebrium.ai/v4/p-xxxxxxxx/1-comfyui/run' \
 --header 'Content-Type: application/json' \
 --header 'Authorization: Bearer <YOUR TOKEN HERE>' \
 --data '{"workflow_values": {

--- a/v4/examples/deploy-a-vision-language-model-with-sglang.mdx
+++ b/v4/examples/deploy-a-vision-language-model-with-sglang.mdx
@@ -236,7 +236,7 @@ cerebrium deploy
 Once deployed, test with a sample request:
 
 ```bash
-curl -X POST "https://api.aws.us-east-1.cerebrium.ai/v4/p-<YOUR-PROJECT-ID>/7-vision-language-sglang/analyze" \
+curl -X POST "https://api.cerebrium.ai/v4/p-xxxxxxxx/7-vision-language-sglang/analyze" \
   -H "Content-Type: application/json" \
   -d '{
     "company_description": "Nike is a global leader in athletic footwear, apparel, and sports equipment known for its innovative designs and the iconic “swoosh” logo. The brand embodies performance, style, and inspiration, empowering athletes worldwide to Just Do It."",

--- a/v4/examples/deploy-an-llm-with-tensorrtllm-tritonserver.mdx
+++ b/v4/examples/deploy-an-llm-with-tensorrtllm-tritonserver.mdx
@@ -452,7 +452,7 @@ After successful deployment, the base endpoint URL appears in the output. Use th
 Send a request to your deployed endpoint:
 
 ```bash
-curl -X POST https://api.aws.us-east-1.cerebrium.ai/v4/<project-id>/<name>/v2/models/llama3_2/infer \
+curl -X POST https://api.cerebrium.ai/v4/p-xxxxxxxx/<name>/v2/models/llama3_2/infer \
   -H "Content-Type: application/json" \
   -d '{
     "inputs": [

--- a/v4/examples/gpt-oss.mdx
+++ b/v4/examples/gpt-oss.mdx
@@ -76,7 +76,7 @@ Deploy by running `cerebrium deploy`. The environment is created and the model i
 Test the endpoint with the following request:
 
 ```
-curl --location 'https://api.aws.us-east-1.cerebrium.ai/v4/p-xxxxxx/7-openai-gpt-oss/v1/chat/completions' \
+curl --location 'https://api.cerebrium.ai/v4/p-xxxxxxxx/7-openai-gpt-oss/v1/chat/completions' \
 --header 'Content-Type: application/json' \
 --header 'Accept: text/event-stream' \
 --data '{"messages": [{"role": "user", "content": "hello how are you"}], "model": "Qwen/Qwen2.5-1.5B-Instruct", "stream": true}'

--- a/v4/examples/high-throughput-embeddings.mdx
+++ b/v4/examples/high-throughput-embeddings.mdx
@@ -202,7 +202,7 @@ Deploy with `cerebrium deploy`.
 After deployment, run inference with a command like:
 
 ```
-curl --location 'https://api.aws.us-east-1.cerebrium.ai/v4/p-xxxx/infinity-throughput/image_embed' \
+curl --location 'https://api.cerebrium.ai/v4/p-xxxxxxxx/infinity-throughput/image_embed' \
 --header 'Content-Type: application/json' \
 --data '{"image_urls": ["https://www.borrowmydoggy.com/_next/image?url=https%3A%2F%2Fcdn.sanity.io%2Fimages%2F4ij0poqn%2Fproduction%2Fe24bfbd855cda99e303975f2bd2a1bf43079b320-800x600.jpg&w=1080&q=80"]}'
 ```

--- a/v4/examples/langchain.mdx
+++ b/v4/examples/langchain.mdx
@@ -198,7 +198,7 @@ cerebrium deploy
 After deployment, make this request:
 
 ```curl
-curl --location --request POST 'https://api.aws.us-east-1.cerebrium.ai/v4/p-xxxxxx/1-langchain-QA/predict' \
+curl --location --request POST 'https://api.cerebrium.ai/v4/p-xxxxxxxx/1-langchain-QA/predict' \
 --header 'Authorization: Bearer <YOUR TOKEN HERE>' \
 --header 'Content-Type: application/json' \
 --data-raw '{

--- a/v4/examples/mistral-vllm.mdx
+++ b/v4/examples/mistral-vllm.mdx
@@ -156,7 +156,7 @@ cerebrium deploy
 After deployment, make this request:
 
 ```curl
-curl --location --request POST 'https://api.aws.us-east-1.cerebrium.ai/v4/p-<YOUR PROJECT ID>/1-faster-inference-with-vllm/predict' \
+curl --location --request POST 'https://api.cerebrium.ai/v4/p-xxxxxxxx/1-faster-inference-with-vllm/predict' \
 --header 'Authorization: Bearer <YOUR TOKEN HERE>' \
 --header 'Content-Type: application/json' \
 --data-raw '{

--- a/v4/examples/openai-compatible-endpoint-vllm.mdx
+++ b/v4/examples/openai-compatible-endpoint-vllm.mdx
@@ -117,7 +117,7 @@ cerebrium deploy
 After deployment, a curl command like this appears:
 
 ```curl
-curl --location 'https://api.aws.us-east-1.cerebrium.ai/v4/p-<YOUR PROJECT ID>/5-openai-compatible-endpoint/{function}' \
+curl --location 'https://api.cerebrium.ai/v4/p-xxxxxxxx/5-openai-compatible-endpoint/{function}' \
 --header 'Content-Type: application/json' \
 --header 'Authorization: Bearer <YOUR TOKEN HERE>' \
 --data '{"..."}'
@@ -130,7 +130,7 @@ import os
 from openai import OpenAI
 
 client = OpenAI(
-    base_url="https://api.aws.us-east-1.cerebrium.ai/v4/p-xxxxxxx/5-openai-compatible-endpoint/run",
+    base_url="https://api.cerebrium.ai/v4/p-xxxxxxxx/5-openai-compatible-endpoint/run",
     api_key="<CEREBRIUM_JWT_TOKEN>",
 )
 

--- a/v4/examples/realtime-voice-agents.mdx
+++ b/v4/examples/realtime-voice-agents.mdx
@@ -467,7 +467,7 @@ A public fork of the PipeCat frontend demonstrates this application. Clone the r
 Follow the instructions in the README.md and then populate the following variables in your .env.development.local
 
 ```
-VITE_SERVER_URL=https://api.aws.us-east-1.cerebrium.ai/v4/p-xxxxx/<APP_NAME> #This is the base url of your pipecat-agent. Do not include the function names
+VITE_SERVER_URL=https://api.cerebrium.ai/v4/p-xxxxxxxx/<APP_NAME> #This is the base url of your pipecat-agent. Do not include the function names
 VITE_SERVER_AUTH= #This is the JWT token you can get from the API Keys section of your Cerebrium Dashboard.
 ```
 

--- a/v4/examples/sdxl.mdx
+++ b/v4/examples/sdxl.mdx
@@ -147,7 +147,7 @@ cerebrium deploy
 After deployment, make this request:
 
 ```curl
-curl --location 'https://api.aws.us-east-1.cerebrium.ai/v4/p-<YOUR PROJECT ID>/3-sdxl-refiner/predict' \
+curl --location 'https://api.cerebrium.ai/v4/p-xxxxxxxx/3-sdxl-refiner/predict' \
 --header 'Content-Type: application/json' \
 --header 'Authorization: Bearer <YOUR TOKEN HERE>' \
 --data '{

--- a/v4/examples/streaming-falcon-7B.mdx
+++ b/v4/examples/streaming-falcon-7B.mdx
@@ -184,7 +184,7 @@ After deployment, make this request:
 </Note>
 
 ```curl
-curl --location --request POST 'https://api.aws.us-east-1.cerebrium.ai/v4/p-<YOUR PROJECT ID>/5-streaming-endpoint/stream' \
+curl --location --request POST 'https://api.cerebrium.ai/v4/p-xxxxxxxx/5-streaming-endpoint/stream' \
 --header 'Authorization: Bearer <YOUR TOKEN HERE>' \
 --header 'Content-Type: application/json' \
 --data-raw '{

--- a/v4/examples/transcribe-whisper.mdx
+++ b/v4/examples/transcribe-whisper.mdx
@@ -146,7 +146,7 @@ cerebrium deploy
 After deployment, make this request:
 
 ```curl
-curl --location 'https://api.aws.us-east-1.cerebrium.ai/v4/p-<YOUR PROJECT ID>/1-whisper-transcription/predict' \
+curl --location 'https://api.cerebrium.ai/v4/p-xxxxxxxx/1-whisper-transcription/predict' \
 --header 'Content-Type: application/json' \
 --header 'Authorization: Bearer <YOUR TOKEN HERE>' \
 --data '{"file_url": "https://your-public-url.com/test.mp3"}''

--- a/v4/examples/twilio-voice-agent.mdx
+++ b/v4/examples/twilio-voice-agent.mdx
@@ -88,7 +88,7 @@ Create a `templates` folder with `stream.xml` inside. This XML response tells Tw
 <Response>
   <Connect>
     <!--Update with your project ID below-->
-    <Stream url="wss://api.aws.us-east-1.cerebrium.ai/v4/p-xxxxxxx/4-twilio-agent/ws"></Stream>
+    <Stream url="wss://api.cerebrium.ai/v4/p-xxxxxxxx/4-twilio-agent/ws"></Stream>
   </Connect>
   <Pause length="40"/>
 </Response>

--- a/v4/examples/wandb-sweep.mdx
+++ b/v4/examples/wandb-sweep.mdx
@@ -322,7 +322,7 @@ from dotenv import load_dotenv
 load_dotenv()
 
 CEREBRIUM_API_KEY = os.getenv("CEREBRIUM_API_KEY")
-ENDPOINT_URL = "https://api.aws.us-east-1.cerebrium.ai/v4/p-xxxxx/wandb-sweep/train_model?async=true"
+ENDPOINT_URL = "https://api.cerebrium.ai/v4/p-xxxxxxxx/wandb-sweep/train_model?async=true"
 
 def train_with_params(params: Dict[str, Any]):
     """


### PR DESCRIPTION
## Summary

- Replace regioned hostnames (`api.aws.us-east-1.cerebrium.ai`) with the global endpoint (`api.cerebrium.ai`) in every endpoint example — 32 files (endpoints, examples, partner services, migrations, TOML reference, introduction)
- Add a note to the REST API page: regioned hostnames continue to work but are proxied to the global router, which can add latency; the global URL is the lowest-latency path
- Normalize project-id placeholders in endpoint URLs to `p-xxxxxxxx` (previously 8+ inconsistent forms: `p-xxxxx`, `<YOUR-PROJECT-ID>`, `{project-id}`, `[project-id]`, ...)
- Fix `ADA_L40S` → `ADA_L40` in the multi-region GPU availability table to match the accepted compute identifier

Deliberately untouched (later PR / different feature):
- Internal app-to-app URLs (`http://api.aws/v4/...`) and custom-domain CNAME targets (`proxy.aws.{region}...`)
- TOML `region` / `provider` config lines and region-selection prose
- `/v4/projects/{project_id}/volumes/...` management API paths (different URL shape)

## Verification

- Repo-wide grep: no regioned public hostnames remain outside the intentional compatibility note
- Prettier clean on all changed files
- Note for reviewer: websocket examples now use `wss://api.cerebrium.ai/...` — worth a smoke test that websocket upgrades behave identically through the global router

🤖 Generated with [Claude Code](https://claude.com/claude-code)