### PR TITLE
fix(docs): restore 150 redirects for legacy v3/Cortex/Conduit URLs

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -282,6 +282,606 @@
     {
       "source": "/docs/cerebrium/:slug*",
       "destination": "/:slug*"
+    },
+    {
+      "source": "/api-reference/subscriptions/remove-project-payment-method",
+      "destination": "/api-reference/subscriptions/remove-payment-method"
+    },
+    {
+      "source": "/v3/examples/logo-controlnet",
+      "destination": "/v4/examples/featured"
+    },
+    {
+      "source": "/api-reference/apps/list-app-containers",
+      "destination": "/api-reference/containers/list-containers"
+    },
+    {
+      "source": "/quickstarts/custom",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/v3/examples/tensorRT",
+      "destination": "/v4/examples/deploy-an-llm-with-tensorrtllm-tritonserver"
+    },
+    {
+      "source": "/conduit/advanced-functionality/model-ensembles",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/cortex/examples/segment_anything",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/getting-started/installation",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/quickstarts/pytorch",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/api-reference/subscriptions/get-project-payment-url",
+      "destination": "/api-reference/subscriptions/get-payment-url"
+    },
+    {
+      "source": "/cortex/advanced-functionality/using-secrets",
+      "destination": "/other-topics/using-secrets"
+    },
+    {
+      "source": "/deployments/async-functions",
+      "destination": "/endpoints/async"
+    },
+    {
+      "source": "/prebuilt-models/language-models/GPT-Neo",
+      "destination": "/v4/examples/featured"
+    },
+    {
+      "source": "/quickstarts/spacy",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/advanced-functionality/persistent-storage",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/api-reference/builds/rebuild-build",
+      "destination": "/api-reference/builds/rebuild"
+    },
+    {
+      "source": "/conduit/examples/xgboost",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/development/serve",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/environments/warm-models",
+      "destination": "/container-images/defining-container-images"
+    },
+    {
+      "source": "/faqs-and-help/fast-deployments-dos-and-donts",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/other-topics/faster-cold-starts",
+      "destination": "/performance/faster-cold-starts"
+    },
+    {
+      "source": "/prebuilt-models/image-models/custom-dreambooth",
+      "destination": "/v4/examples/featured"
+    },
+    {
+      "source": "/prebuilt-models/image-models/img2text",
+      "destination": "/v4/examples/featured"
+    },
+    {
+      "source": "/prebuilt-models/other-models/salesforce-codegen",
+      "destination": "/v4/examples/featured"
+    },
+    {
+      "source": "/quickstarts/huggingface/onnx-conversion",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/v3/examples/streaming-falcon-7B",
+      "destination": "/v4/examples/featured"
+    },
+    {
+      "source": "/v4/examples/langchain_langsmith",
+      "destination": "/v4/examples/langchain-langsmith"
+    },
+    {
+      "source": "/api-reference/apps/list-app-containers-1",
+      "destination": "/api-reference/containers/list-containers"
+    },
+    {
+      "source": "/api-reference/list-all-tokens-for-a-service-account",
+      "destination": "/api-reference/service-accounts/list-service-accounts"
+    },
+    {
+      "source": "/conduit/advanced-functionality/test-locally",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/conduit/advanced-functionality/using-files",
+      "destination": "/storage/managing-files"
+    },
+    {
+      "source": "/conduit/examples/huggingface/transformers",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/cortex/advanced-functionality/long-running-tasks",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/cortex/build-status",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/fine-tuning/language-models/introduction",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/fine-tuning/language-models/training",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/prebuilt-models/image-models/stable-diffusion-2",
+      "destination": "/v4/examples/featured"
+    },
+    {
+      "source": "/prebuilt-models/introduction",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/quickstarts/huggingface/transformers",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/quickstarts/scikit",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/v3/examples/comfyUI",
+      "destination": "/v4/examples/comfyUI"
+    },
+    {
+      "source": "/advanced-functionality/model-ensembles",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/advanced-functionality/persistent-memory",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/api-reference/apps/stop-app-container",
+      "destination": "/api-reference/containers/stop-container"
+    },
+    {
+      "source": "/api-reference/subscriptions/get-project-subscription",
+      "destination": "/api-reference/subscriptions/get-subscription"
+    },
+    {
+      "source": "/conduit/advanced-functionality/persistent-memory",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/conduit/advanced-functionality/processing-functions",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/conduit/advanced-functionality/using-secrets",
+      "destination": "/other-topics/using-secrets"
+    },
+    {
+      "source": "/conduit/advanced-functionality/using-webhook-endpoints",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/conduit/examples/pytorch",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/conduit/examples/spacy",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/cortex/advanced-functionality/async-functions",
+      "destination": "/endpoints/async"
+    },
+    {
+      "source": "/cortex/examples/langchain",
+      "destination": "/v4/examples/langchain-langsmith"
+    },
+    {
+      "source": "/cortex/model-status",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/endpoints/rest-api",
+      "destination": "/endpoints/inference-api"
+    },
+    {
+      "source": "/examples/langchain",
+      "destination": "/v4/examples/langchain-langsmith"
+    },
+    {
+      "source": "/fine-tuning/diffusion-models/dataset",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/fine-tuning/diffusion-models/introduction",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/fine-tuning/diffusion-models/training",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/fine-tuning/language-models/config",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/fine-tuning/language-models/model-specific-docs/training-falcon",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/fine-tuning/language-models/model-specific-docs/training-llama2",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/installation",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/introduction",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/prebuilt-models/image-models/controlnet",
+      "destination": "/v4/examples/featured"
+    },
+    {
+      "source": "/prebuilt-models/image-models/segment-anything",
+      "destination": "/v4/examples/featured"
+    },
+    {
+      "source": "/prebuilt-models/language-models/roberta",
+      "destination": "/v4/examples/featured"
+    },
+    {
+      "source": "/prebuilt-models/language-models/tortoise",
+      "destination": "/v4/examples/featured"
+    },
+    {
+      "source": "/quickstarts/xgboost",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/roadmap",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/test-and-deploy",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/v3/examples/mistral-vllm",
+      "destination": "/v4/examples/openai-compatible-endpoint-vllm"
+    },
+    {
+      "source": "/v4/examples/tensorRT",
+      "destination": "/v4/examples/deploy-an-llm-with-tensorrtllm-tritonserver"
+    },
+    {
+      "source": "/advanced-functionality/using-files",
+      "destination": "/storage/managing-files"
+    },
+    {
+      "source": "/api-reference/apps/create-app-if-it-does-not-exist",
+      "destination": "/api-reference/apps/create-app"
+    },
+    {
+      "source": "/api-reference/apps/get-app-metrics",
+      "destination": "/api-reference/apps/get-app-resource-metrics"
+    },
+    {
+      "source": "/api-reference/apps/get-app-resource-metrics-cpu-memory-gpu",
+      "destination": "/api-reference/apps/get-app-resource-metrics"
+    },
+    {
+      "source": "/api-reference/create-a-new-service-account",
+      "destination": "/api-reference/service-accounts/create-service-account"
+    },
+    {
+      "source": "/api-reference/create-api-key",
+      "destination": "/api-reference/api-keys/create-api-key"
+    },
+    {
+      "source": "/api-reference/list-api-keys",
+      "destination": "/api-reference/api-keys/list-api-keys"
+    },
+    {
+      "source": "/api-reference/projects/list-containers",
+      "destination": "/api-reference/containers/list-containers"
+    },
+    {
+      "source": "/api-reference/subscriptions/get-project-payment-methods",
+      "destination": "/api-reference/subscriptions/remove-payment-method"
+    },
+    {
+      "source": "/api-reference/update-service-account-grants",
+      "destination": "/api-reference/service-accounts/update-service-account"
+    },
+    {
+      "source": "/api-reference/users/list-project-users",
+      "destination": "/api-reference/projects/list-projects"
+    },
+    {
+      "source": "/conduit/advanced-functionality/saving-files",
+      "destination": "/storage/managing-files"
+    },
+    {
+      "source": "/conduit/examples/huggingface/onnx-conversion",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/conduit/examples/onnx",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/conduit/examples/tensorflow",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/conduit/introduction",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/conduit/model-status",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/cortex/advanced-functionality/config-files",
+      "destination": "/toml-reference/toml-reference"
+    },
+    {
+      "source": "/cortex/advanced-functionality/init-cortex-project",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/environments/custom-images",
+      "destination": "/container-images/defining-container-images"
+    },
+    {
+      "source": "/environments/initial-setup",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/environments/using-secrets",
+      "destination": "/other-topics/using-secrets"
+    },
+    {
+      "source": "/examples",
+      "destination": "/v4/examples/featured"
+    },
+    {
+      "source": "/examples/logo-controlnet",
+      "destination": "/v4/examples/featured"
+    },
+    {
+      "source": "/fine-tuning/language-models/dataset",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/misc/faster-model-loading",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/prebuilt-models/image-models/stable-diffusion-upscaler",
+      "destination": "/v4/examples/featured"
+    },
+    {
+      "source": "/prebuilt-models/language-models/falcon",
+      "destination": "/v4/examples/featured"
+    },
+    {
+      "source": "/prebuilt-models/language-models/flanT5",
+      "destination": "/v4/examples/featured"
+    },
+    {
+      "source": "/prebuilt-models/language-models/mt0",
+      "destination": "/v4/examples/featured"
+    },
+    {
+      "source": "/pricing",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/quickstarts/onnx",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/quickstarts/tensorflow",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/v3/examples/transcribe-whisper",
+      "destination": "/v4/examples/transcribe-whisper"
+    },
+    {
+      "source": "/advanced-functionality",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/advanced-functionality/processing-functions",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/api-reference/authentication/authorization-token",
+      "destination": "/api-reference/apps/list-apps"
+    },
+    {
+      "source": "/api-reference/projects/modify-project-onboarding",
+      "destination": "/api-reference/projects/modify-project"
+    },
+    {
+      "source": "/api-reference/subscriptions/change-project-plan",
+      "destination": "/api-reference/subscriptions/change-plan"
+    },
+    {
+      "source": "/api-reference/subscriptions/get-project-invoices",
+      "destination": "/api-reference/projects/get-project-cost"
+    },
+    {
+      "source": "/available-hardware/regions",
+      "destination": "/deployments/multi-region-deployment"
+    },
+    {
+      "source": "/conduit/examples/scikit",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/configuration/toml-reference",
+      "destination": "/toml-reference/toml-reference"
+    },
+    {
+      "source": "/container-images/custom-python-web-servers",
+      "destination": "/container-images/custom-web-servers"
+    },
+    {
+      "source": "/container-images/using-private-docker-registries",
+      "destination": "/container-images/private-docker-registry"
+    },
+    {
+      "source": "/cortex/advanced-functionality/persistent-storage",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/cortex/examples/stable_diffusion",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/deployments/gpu-deployments",
+      "destination": "/hardware/using-gpus"
+    },
+    {
+      "source": "/deployments/long-running-tasks",
+      "destination": "/endpoints/async"
+    },
+    {
+      "source": "/environments/config-files",
+      "destination": "/toml-reference/toml-reference"
+    },
+    {
+      "source": "/environments/legacy-yaml-config",
+      "destination": "/toml-reference/toml-reference"
+    },
+    {
+      "source": "/environments/model-scaling",
+      "destination": "/scaling/scaling-apps"
+    },
+    {
+      "source": "/environments/multi-gpu-inferencing",
+      "destination": "/hardware/using-gpus"
+    },
+    {
+      "source": "/examples/mistral-vllm",
+      "destination": "/v4/examples/openai-compatible-endpoint-vllm"
+    },
+    {
+      "source": "/examples/segment_anything",
+      "destination": "/v4/examples/featured"
+    },
+    {
+      "source": "/examples/stable_diffusion",
+      "destination": "/v4/examples/featured"
+    },
+    {
+      "source": "/examples/streaming-falcon-7B",
+      "destination": "/v4/examples/featured"
+    },
+    {
+      "source": "/examples/transcribe-whisper",
+      "destination": "/v4/examples/transcribe-whisper"
+    },
+    {
+      "source": "/faqs-and-help/fitting-large-models-on-small-gpus",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/fine-tuning/diffusion-models/config",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/fine-tuning/language-models/custom-templates",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/introduction/overview",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/other-concepts/security-and-data-privacy",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/other-topics/fast-deployments-dos-and-donts",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/other-topics/faster-model-loading",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/prebuilt-models",
+      "destination": "/v4/examples/featured"
+    },
+    {
+      "source": "/prebuilt-models/deployment",
+      "destination": "/v4/examples/featured"
+    },
+    {
+      "source": "/prebuilt-models/image-models/esrgan-upscaler",
+      "destination": "/v4/examples/featured"
+    },
+    {
+      "source": "/prebuilt-models/image-models/img2img-stable-diffusion",
+      "destination": "/v4/examples/featured"
+    },
+    {
+      "source": "/prebuilt-models/language-models/llamav2",
+      "destination": "/v4/examples/featured"
+    },
+    {
+      "source": "/prebuilt-models/language-models/pygmalion",
+      "destination": "/v4/examples/featured"
+    },
+    {
+      "source": "/prebuilt-models/language-models/whisper",
+      "destination": "/v4/examples/featured"
+    },
+    {
+      "source": "/scaling/batching-and-concurrency",
+      "destination": "/scaling/batching-concurrency"
+    },
+    {
+      "source": "/scaling/container-images/defining-container-images",
+      "destination": "/container-images/defining-container-images"
+    },
+    {
+      "source": "/v3/examples/langchain",
+      "destination": "/v4/examples/langchain-langsmith"
+    },
+    {
+      "source": "/v3/examples/sdxl",
+      "destination": "/v4/examples/sdxl"
+    },
+    {
+      "source": "/websockets",
+      "destination": "/endpoints/websockets"
     }
   ],
   "integrations": {


### PR DESCRIPTION
The v3 → v4 migration (and the retirement of the Cortex/Conduit frameworks) shipped without redirects, so legacy `/docs/*` URLs still living in Google’s index, LLM answers, GitHub issues, bookmarks and CLI/SDK strings currently hard-404.

**Evidence**
- Google Search Console reports **198 "Not found (404)"** URLs for `cerebrium.ai` (64 of them under docs; the rest are marketing-site URLs and Next.js build assets, out of scope here).
- GA4 (Documentation property) shows **157 distinct dead `/docs/*` URLs**, ~438 views / 28 days, **96.7% bounce**.
- Example: `/docs/v3/examples/tensorRT` → 404 today, though the content lives at `/docs/v4/examples/deploy-an-llm-with-tensorrtllm-tritonserver`.

**The change**
Adds **150** old → new redirects to the existing `redirects` array in `docs.json`. The 2 existing entries are preserved unchanged and in order (2 → 152 total). No other file, and no other key in `docs.json`, is touched — **600 insertions, 0 deletions**. Sources are **docs-root-relative**, matching the existing entries.

## Tested on a local Mintlify preview (`mint dev`)

There’s no preview deployment on this repo, so I ran the docs locally with the pinned `mint` CLI and exercised every rule:

| Test | Result |
|---|---|
| All 150 redirects resolve to their intended destination | ✅ **150/150** |
| The 2 pre-existing wildcard rules still fire (no regression) | ✅ `/cerebrium/getting-started/introduction` → 307 → `/getting-started/introduction` |
| An unmapped path still 404s (no over-matching) | ✅ `/no-such-page-xyz` → 404 |
| `docs.json` passes `prettier --check` (this repo’s lint CI) | ✅ |

## Verified against production before submitting

| Check | Result |
|---|---|
| Sources currently 404 (so no live page is affected) | ✅ **150/150 return 404** |
| Unique destinations currently resolve | ✅ **40/40 return 200** — no redirect points at another 404 |
| Duplicate sources / self-redirects / redirect chains | ✅ none |
| Collision with the 2 existing rules | ✅ none |
| `docs.json` validity | ✅ valid JSON; `$schema` + all 16 top-level keys unchanged |

**Two entries from my original map were deliberately dropped (152 → 150), both after testing:**
1. A malformed source (`ing-started/introduction`) produced by a path-prefix bug in my generator — its source was a marketing-site path outside the Mintlify app, so a `docs.json` redirect could never serve it.
2. `/getting-started/introduction/` (trailing slash) — **production already 308s this to the same destination**, so the rule was redundant.

**How the mapping was built**
Old→new matched by slug + fuzzy match + a curated override table, with every destination asserted to exist in the live docs sitemap. Confidence tiers of the 150 shipping here:

| Tier | Count | Meaning |
|---|---|---|
| HIGH | 41 | Exact rename / unique slug match / hand-curated |
| MEDIUM | 18 | Fuzzy-matched and disambiguated |
| HUB | 86 | Retired content with no 1:1 replacement → nearest live section hub (correct behaviour for removed pages) |
| LOW | 5 | Safe best-guess — all 5 listed below for a quick look |

The 5 LOW-confidence rows, if you want to sanity-check the judgement calls:
- `/getting-started/installation` → `/getting-started/introduction`
- `/api-reference/list-all-tokens-for-a-service-account` → `/api-reference/service-accounts/list-service-accounts`
- `/conduit/advanced-functionality/using-files` → `/storage/managing-files`
- `/advanced-functionality/using-files` → `/storage/managing-files`
- `/conduit/advanced-functionality/saving-files` → `/storage/managing-files`

The 86 HUB rows are the ones most worth a skim if you disagree with any target — they’re retired pages pointed at the nearest live section hub rather than a 1:1 replacement.

**After merge**
```bash
curl -sIL https://cerebrium.ai/docs/v3/examples/tensorRT | grep -Ei "HTTP|location"
# expect 308 → a live v4 page (currently 404)
```

Happy to adjust any of the HUB or LOW destinations if you’d prefer different targets.