### PR TITLE
Sync GPU availability by region with the platform matrix

### DIFF
--- a/deployments/multi-region-deployment.mdx
+++ b/deployments/multi-region-deployment.mdx
@@ -151,8 +151,8 @@ cerebrium region set us-east-1
 
 GPU availability varies across regions due to infrastructure constraints and local demand. CPU workloads run in every region.
 
-| Region                  | Available GPUs                                                                                                                                   |
-| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Region                 | Available GPUs                                                                                                                                                      |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | us-east-1              | BLACKWELL_B300, BLACKWELL_B200, BLACKWELL_RTX6000, HOPPER_H200, HOPPER_H100, AMPERE_A100_80GB, AMPERE_A100_40GB, ADA_L40, ADA_L4, AMPERE_A10, TURING_T4, INF2, TRN1 |
 | us-central1            | BLACKWELL_RTX6000, BLACKWELL_B200, HOPPER_H200                                                                                                                      |
 | eu-north1              | HOPPER_H200, HOPPER_H100, ADA_L40                                                                                                                                   |

--- a/deployments/multi-region-deployment.mdx
+++ b/deployments/multi-region-deployment.mdx
@@ -153,10 +153,8 @@ GPU availability varies across regions due to infrastructure constraints and loc
 
 | Region                  | Available GPUs                                                                                                                                   |
 | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| us-east-1               | BLACKWELL_B300, BLACKWELL_B200, HOPPER_H200, HOPPER_H100, AMPERE_A100_80GB, AMPERE_A100_40GB, ADA_L40, ADA_L4, AMPERE_A10, TURING_T4, INF2, TRN1 |
-| us-central1             | BLACKWELL_RTX6000, BLACKWELL_B200, HOPPER_H200                                                                                                   |
-| eu-north1               | HOPPER_H200, HOPPER_H100, ADA_L40                                                                                                                |
-| us-west-2 (on request)  | HOPPER_H200, HOPPER_H100, AMPERE_A100_80GB, AMPERE_A100_40GB, ADA_L40, ADA_L4, AMPERE_A10, INF2, TRN1                                            |
-| eu-west-2 (on request)  | HOPPER_H100, AMPERE_A10, ADA_L4, TURING_T4                                                                                                       |
-| eu-north-1              | HOPPER_H100, ADA_L40, ADA_L4, AMPERE_A10, TURING_T4, INF2, TRN1                                                                                  |
-| ap-south-1 (on request) | ADA_L4, AMPERE_A10, TURING_T4                                                                                                                    |
+| us-east-1              | BLACKWELL_B300, BLACKWELL_B200, BLACKWELL_RTX6000, HOPPER_H200, HOPPER_H100, AMPERE_A100_80GB, AMPERE_A100_40GB, ADA_L40, ADA_L4, AMPERE_A10, TURING_T4, INF2, TRN1 |
+| us-central1            | BLACKWELL_RTX6000, BLACKWELL_B200, HOPPER_H200                                                                                                                      |
+| eu-north1              | HOPPER_H200, HOPPER_H100, ADA_L40                                                                                                                                   |
+| eu-north-1             | BLACKWELL_RTX6000, HOPPER_H100, ADA_L40, ADA_L4, AMPERE_A10, TURING_T4, INF2, TRN1                                                                                  |
+| eu-west-2 (on request) | HOPPER_H100, AMPERE_A10, ADA_L4, TURING_T4                                                                                                                          |


### PR DESCRIPTION
Brings the **GPU Availability by Region** table in line with the backend `GPUAvailabilityMatrix` (go-build-service), which is what create/update validation actually enforces.

## Changes
- **us-east-1**: add `BLACKWELL_RTX6000` (live in the matrix since the RTX6000 rollout; the hardware page already documents it as Standard plan).
- **eu-north-1**: add `BLACKWELL_RTX6000` (same), and move the row up with the other live regions.
- **Removed rows**: `us-west-2` (mothballed June 2026) and `ap-south-1` (removed from the platform) are no longer deployable, so listing per-GPU availability for them is misleading. Both stay in the *available on request* region list above, which is the accurate framing.

## Notes for reviewer
- `BLACKWELL_B300` is listed here and on the hardware page but is **not** in the validation matrix, so a B300 deploy is rejected today. Left as-is on the assumption it's deliberately pre-announced; flagging in case it isn't.
- The us-east-1 row is unchanged for L4/T4/A10: the ongoing Crusoe L40S enablement (argocd-manifests#983/#988, dashboard-backend#3981) adds capacity behind the same region identifier, not new customer-facing GPU types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)