### PR TITLE
docs: make checkpointing beta status prominent

### DIFF
--- a/performance/checkpointing.mdx
+++ b/performance/checkpointing.mdx
@@ -18,7 +18,11 @@ This is useful for both CPU-only and GPU workloads. For CPU applications, checkp
 
 For example, ML and LLM frameworks often load large model weights and compile CUDA kernels at container start time, which can take many seconds or minutes. Loading from a checkpoint that already contains this initialized state can skip most of that delay.
 
+Since this feature is still in beta, please report all issues to the team via our [Discord Community](https://discord.gg/ATj6USmeE2) or via [Email](mailto:support@cerebrium.ai).
+
 ## How to use
+
+Checkpointing is available in early beta to our customer base.
 
 ### 1. Enable checkpointing in `cerebrium.toml`
 

--- a/performance/checkpointing.mdx
+++ b/performance/checkpointing.mdx
@@ -3,6 +3,13 @@ title: "Memory and GPU Checkpointing (Beta)"
 description: "Snapshot CPU and GPU memory to skip imports, model loading, and CUDA kernel compilation, drastically cutting Cerebrium container cold start times."
 ---
 
+<Warning>
+  Checkpointing is in early beta. Some workloads may fail to checkpoint or
+  restore, and behavior may change as the feature matures. Report issues via
+  the [Discord Community](https://discord.gg/ATj6USmeE2) or
+  [email](mailto:support@cerebrium.ai).
+</Warning>
+
 ## Introduction
 
 Memory checkpointing takes a snapshot of a container's CPU memory and GPU memory, and uses it to speed up the startup of future containers. Applications that perform a large amount of work at container start time benefit the most from this process.
@@ -11,11 +18,7 @@ This is useful for both CPU-only and GPU workloads. For CPU applications, checkp
 
 For example, ML and LLM frameworks often load large model weights and compile CUDA kernels at container start time, which can take many seconds or minutes. Loading from a checkpoint that already contains this initialized state can skip most of that delay.
 
-Since this feature is still in beta, please report all issues to the team via our [Discord Community](https://discord.gg/ATj6USmeE2) or via [Email](mailto:support@cerebrium.ai).
-
 ## How to use
-
-Checkpointing is available in early beta to our customer base.
 
 ### 1. Enable checkpointing in `cerebrium.toml`
 

--- a/performance/checkpointing.mdx
+++ b/performance/checkpointing.mdx
@@ -5,8 +5,8 @@ description: "Snapshot CPU and GPU memory to skip imports, model loading, and CU
 
 <Warning>
   Checkpointing is in early beta. Some workloads may fail to checkpoint or
-  restore, and behavior may change as the feature matures. Report issues via
-  the [Discord Community](https://discord.gg/ATj6USmeE2) or
+  restore, and behavior may change as the feature matures. Report issues via the
+  [Discord Community](https://discord.gg/ATj6USmeE2) or
   [email](mailto:support@cerebrium.ai).
 </Warning>
 


### PR DESCRIPTION
## Summary
- Add a `<Warning>` callout at the top of the checkpointing page stating the feature is in early beta, that some workloads may fail to checkpoint or restore, and where to report issues
- Remove the beta sentence that was buried mid-introduction and the redundant "available in early beta" line under **How to use**, since the callout now covers both

## Verification
- `npx mint broken-links` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)