### PR TITLE
Add contextual AI controls, and 18 redirects for docs pages that 404

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -242,6 +242,9 @@
   "search": {
     "prompt": "Search Cerebrium docs..."
   },
+  "contextual": {
+    "options": ["copy", "view", "chatgpt", "claude"]
+  },
   "logo": {
     "light": "/logo/light.svg",
     "dark": "/logo/dark.svg",
@@ -882,6 +885,78 @@
     {
       "source": "/websockets",
       "destination": "/endpoints/websockets"
+    },
+    {
+      "source": "/fine-tuning/auto-deploying",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/api-reference/apps/create-app-1",
+      "destination": "/api-reference/apps/create-app"
+    },
+    {
+      "source": "/available-hardware",
+      "destination": "/hardware/using-gpus"
+    },
+    {
+      "source": "/api-reference/builds/check-build-service-status",
+      "destination": "/api-reference/builds/health-check"
+    },
+    {
+      "source": "/available-gpus",
+      "destination": "/hardware/using-gpus"
+    },
+    {
+      "source": "/deployments/scaling",
+      "destination": "/scaling/scaling-apps"
+    },
+    {
+      "source": "/endpoints/custom-web-servers",
+      "destination": "/container-images/custom-web-servers"
+    },
+    {
+      "source": "/environments/available-hardware",
+      "destination": "/hardware/using-gpus"
+    },
+    {
+      "source": "/deployments/persistent-storage",
+      "destination": "/storage/managing-files"
+    },
+    {
+      "source": "/environments/using-gpus",
+      "destination": "/hardware/using-gpus"
+    },
+    {
+      "source": "/faster-cold-starts",
+      "destination": "/performance/faster-cold-starts"
+    },
+    {
+      "source": "/getting-started/pricing",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/hardware/available-gpus",
+      "destination": "/hardware/using-gpus"
+    },
+    {
+      "source": "/hardware/gpu",
+      "destination": "/hardware/using-gpus"
+    },
+    {
+      "source": "/hardware/regions",
+      "destination": "/deployments/multi-region-deployment"
+    },
+    {
+      "source": "/logging/arize",
+      "destination": "/other-topics/request-response-logging"
+    },
+    {
+      "source": "/security-and-privacy/soc2-compliance",
+      "destination": "/security"
+    },
+    {
+      "source": "/storage/persistent-storage",
+      "destination": "/storage/managing-files"
     }
   ],
   "integrations": {


### PR DESCRIPTION
Two small additive changes to `docs.json`. Batched into one PR rather than two so it's a single review.

## 1. `contextual` — per-page AI hand-off controls

```json
"contextual": {
  "options": ["copy", "view", "chatgpt", "claude"]
}
```

This turns on the per-page controls: **Copy page**, **View as Markdown**, **Open in ChatGPT**, **Open in Claude**.

The capability is already there — every docs page already serves clean markdown at its `.md` URL, each prefixed with a pointer to `llms.txt`. Only the UI control was missing, so today a reader who wants to hand a page to an assistant has to copy the rendered HTML out of the browser.

A DOM check at 1440px and 420px confirmed none of these controls currently render; the mobile "More actions" menu only contains Contact Us and Sign Up.

Option values are the exact enum from `https://mintlify.com/docs.json` rather than guessed. I validated the file against that schema before and after: the block is valid, and a deliberately invalid option is rejected by the same validator — so the check is actually discriminating, not just passing.

## 2. Eighteen redirects for doc paths that 404

Same method as the 152 redirects already in this file — which, for what it's worth, went from ~438 404-views per 28 days down to ~32 after they shipped.

Sources come from real GA4 traffic on paths that return 404; each destination was chosen by hand against the current page inventory rather than by string similarity, because an automated pass produced generic hub pages for two-thirds of them.

Re-verified against production on 2026-07-29, immediately before opening this:

- **18/18** sources still return 404 (so none of these rows is obsolete)
- **18/18** destinations return 200
- **0** duplicate an entry already in `docs.json`

The check ran with controls in both directions — an impossible docs path returning 404 and a known-good page returning 200 — so a green result can't come from a probe that silently fails.

Examples: `/available-gpus` and `/hardware/gpu` → `/hardware/using-gpus`; `/deployments/persistent-storage` → `/storage/managing-files`; `/api-reference/apps/create-app-1` → `/api-reference/apps/create-app`.

## Risk

Purely additive: 75 lines, no existing line modified. I made this as a text edit rather than a JSON round-trip specifically so the diff stays readable — reformatting all 896 lines would have hidden a 20-line change.

Verified programmatically that the only two top-level keys that differ from upstream are `contextual` and `redirects`, that all 152 existing redirects are byte-identical and in their original order, and that no duplicate `source` was introduced.

There's one pre-existing schema warning on `css` at the top level, present identically before and after this change — flagging it only so it isn't mistaken for something this PR caused.