### PR TITLE
Phase 0 docs 1/3: MCP proxy wiring and contextual agent config

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -243,7 +243,21 @@
     "prompt": "Search Cerebrium docs..."
   },
   "contextual": {
-    "options": ["copy", "view", "chatgpt", "claude"]
+    "options": [
+      "copy",
+      "view",
+      "assistant",
+      "mcp",
+      "add-mcp",
+      "cursor",
+      "vscode",
+      "chatgpt",
+      "claude",
+      "perplexity"
+    ]
+  },
+  "markdown": {
+    "instructions": "Cerebrium's documentation MCP server is available at https://cerebrium.ai/docs/mcp for searching and querying these docs directly. Install the Cerebrium agent skill with `npx skills add https://cerebrium.ai/docs`. Append .md to any docs page URL to fetch that page as plain Markdown. API keys and authentication tokens are created in the Cerebrium dashboard at https://dashboard.cerebrium.ai."
   },
   "logo": {
     "light": "/logo/light.svg",

--- a/vercel.json
+++ b/vercel.json
@@ -19,51 +19,67 @@
   "rewrites": [
     {
       "source": "/_mintlify/:path*",
-      "destination": "https://cerebrium.mintlify.dev/_mintlify/:path*"
+      "destination": "https://cerebrium.mintlify.site/_mintlify/:path*"
     },
     {
       "source": "/api/request",
-      "destination": "https://cerebrium.mintlify.dev/_mintlify/api/request"
+      "destination": "https://cerebrium.mintlify.site/_mintlify/api/request"
     },
     {
       "source": "/cerebrium",
-      "destination": "https://cerebrium.mintlify.dev/docs"
+      "destination": "https://cerebrium.mintlify.site/docs"
     },
     {
       "source": "/cerebrium/:path*",
-      "destination": "https://cerebrium.mintlify.dev/docs/:path*"
+      "destination": "https://cerebrium.mintlify.site/docs/:path*"
     },
     {
       "source": "/docs",
-      "destination": "https://cerebrium.mintlify.dev/docs"
+      "destination": "https://cerebrium.mintlify.site/docs"
     },
     {
       "source": "/docs/llms.txt",
-      "destination": "https://cerebrium.mintlify.dev/llms.txt"
+      "destination": "https://cerebrium.mintlify.site/docs/llms.txt"
     },
     {
       "source": "/docs/llms-full.txt",
-      "destination": "https://cerebrium.mintlify.dev/llms-full.txt"
+      "destination": "https://cerebrium.mintlify.site/docs/llms-full.txt"
     },
     {
       "source": "/docs/sitemap.xml",
-      "destination": "https://cerebrium.mintlify.dev/sitemap.xml"
+      "destination": "https://cerebrium.mintlify.site/docs/sitemap.xml"
     },
     {
       "source": "/docs/robots.txt",
-      "destination": "https://cerebrium.mintlify.dev/robots.txt"
+      "destination": "https://cerebrium.mintlify.site/docs/robots.txt"
     },
     {
       "source": "/docs/mcp",
-      "destination": "https://cerebrium.mintlify.dev/mcp"
+      "destination": "https://cerebrium.mintlify.site/docs/mcp"
+    },
+    {
+      "source": "/.well-known/mcp.json",
+      "destination": "https://cerebrium.mintlify.site/docs/.well-known/mcp.json"
+    },
+    {
+      "source": "/.well-known/skills/:path*",
+      "destination": "https://cerebrium.mintlify.site/docs/.well-known/skills/:path*"
+    },
+    {
+      "source": "/.well-known/agent-skills/:path*",
+      "destination": "https://cerebrium.mintlify.site/docs/.well-known/agent-skills/:path*"
+    },
+    {
+      "source": "/.well-known/agent-card.json",
+      "destination": "https://cerebrium.mintlify.site/docs/.well-known/agent-card.json"
     },
     {
       "source": "/docs/:path*",
-      "destination": "https://cerebrium.mintlify.dev/docs/:path*"
+      "destination": "https://cerebrium.mintlify.site/docs/:path*"
     },
     {
       "source": "/mintlify-assets/:path+",
-      "destination": "https://cerebrium.mintlify.dev/mintlify-assets/:path+"
+      "destination": "https://cerebrium.mintlify.site/mintlify-assets/:path+"
     }
   ]
 }


### PR DESCRIPTION
## Context

Part of Phase 0 of the Agentic Cerebrium initiative: making Cerebrium fully usable by coding agents (Claude Code, Cursor, Codex, Copilot). Agents consume these docs through the Mintlify MCP server, llms.txt, and .md exports, and today the entry points are broken: the MCP handshake 406s at cerebrium.ai/docs/mcp, several proxy rewrites silently 404, and key config defaults documented here contradict the backend, which steers agent-authored `cerebrium.toml` files wrong. Every content claim in this stack was verified against dashboard-backend source (file:line refs below) on 2026-08-04.

This PR is layer 1 of a 3-PR stack (one reviewable unit per layer, merge bottom-up; merging a lower layer auto-retargets the ones above):
1. #308 MCP proxy wiring + contextual agent config
2. #309 content accuracy fixes (defaults, GPU tables, curl snippets, regions)
3. #310 delete intentionally orphaned pages (+ redirects)

Related: the CloudFront half of the MCP fix (cerebrium.ai apex routing) is CerebriumAI/eks#431; this repo's vercel.json covers the docs Vercel project.

Bottom layer of the Phase 0 docs stack: agent-discovery proxy wiring plus contextual config only. Content-accuracy fixes and orphan-page cleanup moved to the layers above (#309, #310). Every proxy target was curl-probed 200 before writing.

## Changes

**vercel.json (proxy wiring)**
- Migrated all rewrites from legacy `cerebrium.mintlify.dev` to `cerebrium.mintlify.site` (current Mintlify guidance).
- Fixed the broken `/docs/mcp` rewrite: old target `.dev/mcp` 404s (missing `/docs` base path); new target `.site/docs/mcp` returns 200 to a POST MCP initialize handshake.
- Fixed four silently broken rewrites (`llms.txt`, `llms-full.txt`, `sitemap.xml`, `robots.txt`) that pointed at the `.site` host root where they 404; the `.site` host keeps the `/docs` base path.
- Added agent-discovery rewrites: `/.well-known/mcp.json`, `/.well-known/skills/*`, `/.well-known/agent-skills/*`, `/.well-known/agent-card.json`. Reserved paths (`acme-challenge`, `vercel`) untouched. `/docs/skill.md` is covered by the `/docs/:path*` catch-all (probed 200).

**docs.json**
- Extended the existing `contextual` menu (4 options) to 10: copy, view, assistant, mcp, add-mcp, cursor, vscode, chatgpt, claude, perplexity.
- Added `markdown.instructions` (feeds llms.txt and .md exports): MCP endpoint, `npx skills add`, `.md` suffix, dashboard auth pointer.

## How to test this layer

1. JSON validity: `python3 -m json.tool docs.json > /dev/null && python3 -m json.tool vercel.json > /dev/null`.
2. MCP rewrite (against the preview or prod Vercel domain after merge): `curl -s -X POST https://<domain>/docs/mcp -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' --data '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"probe","version":"0"}}}'` expects HTTP 200 (note: via cerebrium.ai this still 406s until the CloudFront PR in eks is applied; test against the Vercel domain directly).
3. Discovery files: `curl -s https://<domain>/.well-known/mcp.json` and `/.well-known/agent-card.json` expect 200; `/docs/llms.txt`, `/docs/sitemap.xml`, `/docs/robots.txt` expect 200 (these were broken before).
4. On the Vercel preview deployment: the contextual menu on any docs page shows the 10 options.

## Notes

- The proxied `/.well-known/mcp.json` body still advertises an internal mintlify.me URL; rewrites cannot fix response bodies. Raise with Mintlify (tracked in plan.md).
- Root-level `/.well-known/*` rewrites only serve traffic that reaches this Vercel project; apex cerebrium.ai routing is the CloudFront change in the eks repo (separate PR).

Stack position: 1 of 3 (proxy wiring + contextual config -> content accuracy -> orphan cleanup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


