### PR TITLE
Phase 0 docs 2/3: content accuracy fixes (defaults, GPU tables, curl snippets, regions)

### DIFF
--- a/deployments/multi-region-deployment.mdx
+++ b/deployments/multi-region-deployment.mdx
@@ -151,12 +151,12 @@ cerebrium region set us-east-1
 
 GPU availability varies across regions due to infrastructure constraints and local demand. CPU workloads run in every region.
 
-| Region                  | Available GPUs                                                                                                                                   |
-| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| us-east-1               | BLACKWELL_B200, HOPPER_H200, HOPPER_H100, AMPERE_A100_80GB, AMPERE_A100_40GB, ADA_L40, ADA_L4, AMPERE_A10, TURING_T4, INF2, TRN1                 |
-| us-central1             | BLACKWELL_RTX6000, BLACKWELL_B200, HOPPER_H200                                                                                                   |
-| eu-north1 (Finland)     | HOPPER_H200, HOPPER_H100, ADA_L40                                                                                                                |
-| us-west-2 (on request)  | HOPPER_H200, HOPPER_H100, AMPERE_A100_80GB, AMPERE_A100_40GB, ADA_L40, ADA_L4, AMPERE_A10, INF2, TRN1                                            |
-| eu-west-2 (on request)  | HOPPER_H100, AMPERE_A10, ADA_L4, TURING_T4                                                                                                       |
-| eu-north-1 (Stockholm)  | HOPPER_H100, ADA_L40, ADA_L4, AMPERE_A10, TURING_T4, INF2, TRN1                                                                                  |
-| ap-south-1 (on request) | ADA_L4, AMPERE_A10, TURING_T4                                                                                                                    |
+| Region                  | Available GPUs                                                                                                                   |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| us-east-1               | BLACKWELL_B200, HOPPER_H200, HOPPER_H100, AMPERE_A100_80GB, AMPERE_A100_40GB, ADA_L40, ADA_L4, AMPERE_A10, TURING_T4, INF2, TRN1 |
+| us-central1             | BLACKWELL_RTX6000, BLACKWELL_B200, HOPPER_H200                                                                                   |
+| eu-north1 (Finland)     | HOPPER_H200, HOPPER_H100, ADA_L40                                                                                                |
+| us-west-2 (on request)  | HOPPER_H200, HOPPER_H100, AMPERE_A100_80GB, AMPERE_A100_40GB, ADA_L40, ADA_L4, AMPERE_A10, INF2, TRN1                            |
+| eu-west-2 (on request)  | HOPPER_H100, AMPERE_A10, ADA_L4, TURING_T4                                                                                       |
+| eu-north-1 (Stockholm)  | HOPPER_H100, ADA_L40, ADA_L4, AMPERE_A10, TURING_T4, INF2, TRN1                                                                  |
+| ap-south-1 (on request) | ADA_L4, AMPERE_A10, TURING_T4                                                                                                    |

--- a/deployments/multi-region-deployment.mdx
+++ b/deployments/multi-region-deployment.mdx
@@ -153,10 +153,10 @@ GPU availability varies across regions due to infrastructure constraints and loc
 
 | Region                  | Available GPUs                                                                                                                                   |
 | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| us-east-1               | BLACKWELL_B300, BLACKWELL_B200, HOPPER_H200, HOPPER_H100, AMPERE_A100_80GB, AMPERE_A100_40GB, ADA_L40, ADA_L4, AMPERE_A10, TURING_T4, INF2, TRN1 |
+| us-east-1               | BLACKWELL_B200, HOPPER_H200, HOPPER_H100, AMPERE_A100_80GB, AMPERE_A100_40GB, ADA_L40, ADA_L4, AMPERE_A10, TURING_T4, INF2, TRN1                 |
 | us-central1             | BLACKWELL_RTX6000, BLACKWELL_B200, HOPPER_H200                                                                                                   |
-| eu-north1               | HOPPER_H200, HOPPER_H100, ADA_L40                                                                                                                |
+| eu-north1 (Finland)     | HOPPER_H200, HOPPER_H100, ADA_L40                                                                                                                |
 | us-west-2 (on request)  | HOPPER_H200, HOPPER_H100, AMPERE_A100_80GB, AMPERE_A100_40GB, ADA_L40, ADA_L4, AMPERE_A10, INF2, TRN1                                            |
 | eu-west-2 (on request)  | HOPPER_H100, AMPERE_A10, ADA_L4, TURING_T4                                                                                                       |
-| eu-north-1              | HOPPER_H100, ADA_L40, ADA_L4, AMPERE_A10, TURING_T4, INF2, TRN1                                                                                  |
+| eu-north-1 (Stockholm)  | HOPPER_H100, ADA_L40, ADA_L4, AMPERE_A10, TURING_T4, INF2, TRN1                                                                                  |
 | ap-south-1 (on request) | ADA_L4, AMPERE_A10, TURING_T4                                                                                                                    |

--- a/endpoints/async.mdx
+++ b/endpoints/async.mdx
@@ -8,10 +8,10 @@ Some apps require asynchronous "fire-and-forget" execution. In this model, Cereb
 Enable async execution by adding the `async=true` query parameter to the request:
 
 ```bash
-curl -X POST https://api.cerebrium.ai/v4/p-xxxxxxxx/<YOUR-APP>/run?async=true'\
-       -H 'Content-Type: application/json'\
-       -H 'Authorization: Bearer <YOUR-JWT-TOKEN>\
-       --data '{"param": "hello world"}'
+curl -X POST 'https://api.cerebrium.ai/v4/p-xxxxxxxx/<YOUR-APP>/run?async=true' \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer <YOUR-JWT-TOKEN>' \
+  --data '{"param": "hello world"}'
 ```
 
 This _immediately_ returns a `202 Accepted` response containing only a `run_id`:
@@ -38,10 +38,10 @@ Returning a response while the application is still processing causes Cerebrium 
 Because async calls do not return a response to the caller, the function must export any relevant data itself. Combine async execution with a `webhookEndpoint` to have Cerebrium automatically forward the function's response body:
 
 ```bash
-curl -X POST <https://api.cerebrium.ai/v4/>p-xxxxxxxx/<YOUR-APP>/run?async=true&webhookEndpoint=https%3A%2F%2Fwebhook.site%2F'\
- -H 'Content-Type: application/json'\
- -H 'Authorization: Bearer <YOUR-JWT-TOKEN>\
- --data '{"param": "hello world"}'
+curl -X POST 'https://api.cerebrium.ai/v4/p-xxxxxxxx/<YOUR-APP>/run?async=true&webhookEndpoint=https%3A%2F%2Fwebhook.site%2F' \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer <YOUR-JWT-TOKEN>' \
+  --data '{"param": "hello world"}'
 ```
 
 This is a proxy-level feature — no code changes are required to use webhook forwarding. In the dashboard, the function is marked **async** but still shows the status of the internal synchronous call (e.g. if the call failed, the async request state is `failure`).

--- a/endpoints/streaming.mdx
+++ b/endpoints/streaming.mdx
@@ -22,11 +22,11 @@ def run(upper_range: int):
 Deploy this snippet and call the endpoint. SSE events appear progressively, one per second:
 
 ```bash
-curl -X POST https://api.cerebrium.ai/v4/p-xxxxxxxx/2-streaming-endpoint/run \
-       -H 'Content-Type: application/json'\
-       -H 'Accept: text/event-stream\
-       -H 'Authorization: Bearer <YOUR-JWT-TOKEN>\
-       --data '{"upper_range": 3}'
+curl -X POST 'https://api.cerebrium.ai/v4/p-xxxxxxxx/2-streaming-endpoint/run' \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: text/event-stream' \
+  -H 'Authorization: Bearer <YOUR-JWT-TOKEN>' \
+  --data '{"upper_range": 3}'
 ```
 
 This should output:

--- a/endpoints/webhook.mdx
+++ b/endpoints/webhook.mdx
@@ -6,10 +6,10 @@ description: "Forward responses to a specified webhook"
 Forward function response data to an external endpoint via POST by adding the `webhookEndpoint` query parameter to any API call:
 
 ```bash
-curl -X POST https://api.cerebrium.ai/v4/p-xxxxxxxx/<YOUR-APP>/run?webhookEndpoint=https%3A%2F%2Fwebhook.site%2F'\
-       -H 'Content-Type: application/json'\
-       -H 'Authorization: Bearer <YOUR-JWT-TOKEN>\
-       --data '{"param": "hello world"}'
+curl -X POST 'https://api.cerebrium.ai/v4/p-xxxxxxxx/<YOUR-APP>/run?webhookEndpoint=https%3A%2F%2Fwebhook.site%2F' \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer <YOUR-JWT-TOKEN>' \
+  --data '{"param": "hello world"}'
 ```
 
 The proxy forwards the response body as a POST request to the specified webhook — no code changes required. Ensure the webhook endpoint accepts POST requests. Webhook forwarding works with both Cortex and Custom runtimes, but only for HTTP requests (not WebSockets).
@@ -46,9 +46,9 @@ For example, if the function returns `{"smile": "wave"}`, the proxy sends a POST
 </Note>
 
 ```bash
-curl -X POST https://webhook.site/'\
-       -H 'Content-Type: application/json'\
-       --data '{"smile": "wave"}'
+curl -X POST 'https://webhook.site/' \
+  -H 'Content-Type: application/json' \
+  --data '{"smile": "wave"}'
 ```
 
 ## Webhook Signature Verification

--- a/hardware/cpu-and-memory.mdx
+++ b/hardware/cpu-and-memory.mdx
@@ -39,20 +39,19 @@ Allocate system memory equal to the GPU's VRAM capacity as a baseline. This acco
 
 Resource limits depend on the selected hardware configuration:
 
-| Hardware Type     | Max CPU Cores | Max Memory (GB) |
-| ----------------- | ------------- | --------------- |
-| CPU Only          | 48            | 96              |
-| ADA_L40           | 16            | 128             |
-| AMPERE_A100       | 12            | 140             |
-| AMPERE_A10        | 48            | 192             |
-| ADA_L4            | 48            | 192             |
-| TURING_T4         | 48            | 192             |
-| BLACKWELL_RTX6000 | 24            | 218             |
-| HOPPER_H100       | 24            | 256             |
-| HOPPER_H200       | 24            | 256             |
-| BLACKWELL_B200    | 24            | 256             |
-| BLACKWELL_B300    | 24            | 512             |
-| TRN1              | 128           | 512             |
+| Hardware Type                       | Max CPU Cores | Max Memory (GB) |
+| ----------------------------------- | ------------- | --------------- |
+| CPU Only                            | 48            | 96              |
+| ADA_L40                             | 16            | 128             |
+| AMPERE_A100_40GB / AMPERE_A100_80GB | 12            | 140             |
+| AMPERE_A10                          | 48            | 192             |
+| ADA_L4                              | 48            | 192             |
+| TURING_T4                           | 48            | 192             |
+| BLACKWELL_RTX6000                   | 24            | 218             |
+| HOPPER_H100                         | 24            | 256             |
+| HOPPER_H200                         | 24            | 256             |
+| BLACKWELL_B200                      | 24            | 256             |
+| TRN1                                | 128           | 512             |
 
 ## Memory Optimization
 

--- a/hardware/using-gpus.mdx
+++ b/hardware/using-gpus.mdx
@@ -13,27 +13,38 @@ Configure GPUs in the `[cerebrium.hardware]` section of `cerebrium.toml`, specif
 
 ## Available GPUs
 
-The platform offers GPUs ranging from cost-effective development options to high-end enterprise hardware.
+The platform offers GPUs ranging from cost-effective development options to high-end enterprise hardware, alongside CPU-only compute and AWS accelerators.
 
-| GPU Model    | Identifier        | VRAM (GB) | Max GPUs | Plan required |
-| ------------ | ----------------- | --------- | -------- | ------------- |
-| NVIDIA B300  | BLACKWELL_B300    | 262       | 8        | Enterprise    |
-| NVIDIA B200  | BLACKWELL_B200    | 180       | 8        | Enterprise    |
-| NVIDIA H200  | HOPPER_H200       | 141       | 8        | Enterprise    |
-| NVIDIA H100  | HOPPER_H100       | 80        | 8        | Enterprise    |
-| RTX PRO 6000 | BLACKWELL_RTX6000 | 96        | 8        | Standard      |
-| NVIDIA A100  | AMPERE_A100_80GB  | 80        | 8        | Standard      |
-| NVIDIA A100  | AMPERE_A100_40GB  | 40        | 8        | Standard      |
-| NVIDIA L40s  | ADA_L40           | 48        | 8        | Hobby+        |
-| NVIDIA L4    | ADA_L4            | 24        | 8        | Hobby+        |
-| NVIDIA A10   | AMPERE_A10        | 24        | 8        | Hobby+        |
-| NVIDIA T4    | TURING_T4         | 16        | 8        | Hobby+        |
-| AWS Trainium | TRN1              | 32        | 8        | Hobby+        |
+| Compute         | Identifier        | VRAM (GB) | Max GPUs | Plan required |
+| --------------- | ----------------- | --------- | -------- | ------------- |
+| NVIDIA B200     | BLACKWELL_B200    | 180       | 8        | Standard+     |
+| NVIDIA H200     | HOPPER_H200       | 141       | 8        | Standard+     |
+| NVIDIA H100     | HOPPER_H100       | 80        | 8        | Standard+     |
+| RTX PRO 6000    | BLACKWELL_RTX6000 | 96        | 8        | Standard+     |
+| NVIDIA A100     | AMPERE_A100_80GB  | 80        | 8        | Standard+     |
+| NVIDIA A100     | AMPERE_A100_40GB  | 40        | 8        | Standard+     |
+| NVIDIA L40s     | ADA_L40           | 48        | 8        | Hobby+        |
+| NVIDIA L4       | ADA_L4            | 24        | 8        | Hobby+        |
+| NVIDIA A10      | AMPERE_A10        | 24        | 8        | Hobby+        |
+| NVIDIA T4       | TURING_T4         | 16        | 8        | Hobby+        |
+| AWS Inferentia2 | INF2              | 32        | 8        | Hobby+        |
+| AWS Trainium    | TRN1              | 32        | 8        | Enterprise    |
+| CPU only        | CPU               | -         | -        | Hobby+        |
 
 <Info>
   The identifier is used in the `cerebrium.toml` file. It consists of the GPU
   model generation and model name to avoid ambiguity.
 </Info>
+
+### Plan availability
+
+Compute types are gated by plan:
+
+- **Hobby** (6 types): CPU, TURING_T4, AMPERE_A10, ADA_L4, ADA_L40, INF2
+- **Standard** (12 types): everything in Hobby, plus AMPERE_A100_40GB, AMPERE_A100_80GB, HOPPER_H100, HOPPER_H200, BLACKWELL_B200, BLACKWELL_RTX6000
+- **Enterprise** (all 13 types): everything in Standard, plus TRN1
+
+Deploying with a compute type outside the project's plan is rejected at deploy time. [Upgrade the plan](https://dashboard.cerebrium.ai) or contact [sales@cerebrium.ai](mailto:sales@cerebrium.ai) for per-project exceptions.
 
 <Tip>
   GPU selection is also possible using the `--compute` and `--gpu-count` flags

--- a/scaling/batching-concurrency.mdx
+++ b/scaling/batching-concurrency.mdx
@@ -18,7 +18,7 @@ GPUs excel at parallel processing, so concurrent request handling utilizes GPU r
 
 ## Understanding Batching
 
-Batching determines how concurrent requests are grouped and executed within an instance. Concurrency controls the number of simultaneous requests; batching controls how those requests are processed together. The default concurrency is 1 request per container.
+Batching determines how concurrent requests are grouped and executed within an instance. Concurrency controls the number of simultaneous requests; batching controls how those requests are processed together. The default concurrency is 1 request per container for GPU apps and 100 for CPU-only apps.
 
 Cerebrium supports two approaches to request batching.
 

--- a/toml-reference/toml-reference.mdx
+++ b/toml-reference/toml-reference.mdx
@@ -138,10 +138,10 @@ The `[cerebrium.scaling]` section controls auto-scaling behavior.
 | Option                      | Type    | Default                   | CLI Requirement | Description                                                                                                                                                                                             |
 | --------------------------- | ------- | ------------------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | min_replicas                | integer | 0                         | 2.1.2+          | Minimum running instances                                                                                                                                                                               |
-| max_replicas                | integer | 2                         | 2.1.2+          | Maximum running instances                                                                                                                                                                               |
-| replica_concurrency         | integer | 10                        | 2.1.2+          | Concurrent requests per replica                                                                                                                                                                         |
-| response_grace_period       | integer | 3600                      | 2.1.2+          | Grace period in seconds                                                                                                                                                                                 |
-| cooldown                    | integer | 1800                      | 2.1.2+          | Time window (seconds) that must pass at reduced concurrency before scaling down. Helps avoid cold starts from brief traffic dips.                                                                       |
+| max_replicas                | integer | 1                         | 2.1.2+          | Maximum running instances                                                                                                                                                                               |
+| replica_concurrency         | integer | 1 (GPU), 100 (CPU)        | 2.1.2+          | Concurrent requests per replica. Defaults to 1 for GPU compute types and 100 when compute is CPU                                                                                                        |
+| response_grace_period       | integer | 900                       | 2.1.2+          | Grace period in seconds                                                                                                                                                                                 |
+| cooldown                    | integer | 10                        | 2.1.2+          | Time window (seconds) that must pass at reduced concurrency before scaling down. Helps avoid cold starts from brief traffic dips.                                                                       |
 | scaling_metric              | string  | "concurrency_utilization" | 2.1.2+          | Metric for scaling decisions (concurrency_utilization, requests_per_second, cpu_utilization, memory_utilization)                                                                                        |
 | scaling_target              | integer | 100                       | 2.1.2+          | Target value for scaling metric (percentage for utilization metrics, absolute value for requests_per_second)                                                                                            |
 | scaling_buffer              | integer | optional                  | 2.1.2+          | Additional replica capacity above what scaling metric suggests                                                                                                                                          |
@@ -246,8 +246,8 @@ region = "global"
 min_replicas = 0
 max_replicas = 2
 replica_concurrency = 10
-response_grace_period = 3600
-cooldown = 1800
+response_grace_period = 900
+cooldown = 10
 scaling_metric = "concurrency_utilization"
 scaling_target = 100
 evaluation_interval_seconds = 30


### PR DESCRIPTION
## Context

Part of Phase 0 of the Agentic Cerebrium initiative: making Cerebrium fully usable by coding agents (Claude Code, Cursor, Codex, Copilot). Agents consume these docs through the Mintlify MCP server, llms.txt, and .md exports, and today the entry points are broken: the MCP handshake 406s at cerebrium.ai/docs/mcp, several proxy rewrites silently 404, and key config defaults documented here contradict the backend, which steers agent-authored `cerebrium.toml` files wrong. Every content claim in this stack was verified against dashboard-backend source (file:line refs below) on 2026-08-04.

This PR is layer 2 of a 3-PR stack (one reviewable unit per layer, merge bottom-up; merging a lower layer auto-retargets the ones above):
1. #308 MCP proxy wiring + contextual agent config
2. #309 content accuracy fixes (defaults, GPU tables, curl snippets, regions)
3. #310 delete intentionally orphaned pages (+ redirects)

Related: the CloudFront half of the MCP fix (cerebrium.ai apex routing) is CerebriumAI/eks#431; this repo's vercel.json covers the docs Vercel project.

Middle layer of the Phase 0 docs stack: content-accuracy fixes only, all verified against dashboard-backend source. Builds on the proxy-wiring layer (#308).

## Changes

- Cooldown default corrected 1800 -> 10 in the toml-reference table and sample (`create_app/api/api.go:63` and the github/partner siblings; 1800 appears nowhere in backend code).
- replica_concurrency contradiction resolved with backend truth: default is 1 for GPU compute types, 100 for CPU (`create_app/api/api.go:134-140`); both toml-reference.mdx and batching-concurrency.mdx now say so.
- response_grace_period corrected 3600 -> 900 and max_replicas 2 -> 1 (same backend defaults file).
- GPU tables reconciled against the canonical 13-value enum (`go-build-service/src/libs/apps/inputs.go:28`): BLACKWELL_B300 removed everywhere (backend rejects it), CPU and INF2 rows added, AMPERE_A100 rows versioned, plan-availability section added (hobby 6 / standard 12 / enterprise 13 per `plans.go`).
- eu-north1 vs eu-north-1 "duplicate" was REFUTED: both are real distinct regions (Nebius Finland vs AWS Stockholm, `region.go:76-78`); rows in multi-region-deployment.mdx are now annotated with locations instead of one being deleted.
- Fixed five broken curl snippets (stray or unterminated quotes, angle-bracket URL, unquoted `&`) in endpoints/async.mdx, webhook.mdx and streaming.mdx (curl block only; the streaming falcon-link change lives in the layer above, #310).
- localhost link in defining-container-images.mdx replaced with the relative page path.

## How to test this layer

1. Extract each bash code fence from endpoints/async.mdx, webhook.mdx and streaming.mdx and run `bash -n` on it; all parse (they previously failed shell parsing). Or copy each fixed curl snippet and run it against a real app with a valid API key.
2. Spot-check content claims against backend: `create_app/api/api.go:63` (cooldown 10), `:73` (grace 900), `:64` (max_replicas 1), `:134-140` (concurrency 1 GPU / 100 CPU), `inputs.go:28` (13 GPU types).
3. JSON sanity unchanged by this layer: `python3 -m json.tool docs.json > /dev/null && python3 -m json.tool vercel.json > /dev/null`.

Stack position: 2 of 3 (proxy wiring + contextual config -> content accuracy -> orphan cleanup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


