### PR TITLE
docs(deepgram): note that the Engine port must stay 8055

### DIFF
--- a/partner-services/deepgram.mdx
+++ b/partner-services/deepgram.mdx
@@ -61,12 +61,10 @@ cerebrium cp nova-3-general.en.streaming.123456.dg deepgram-models/nova-3-genera
    ```
 
 <Warning>
-  Leave the Engine's `[server]` port set to **8055**. Cerebrium watches this
-  port to tell when the Engine has finished loading your models and the app is
-  ready to serve traffic. If you change it, requests are sent before the Engine
-  can answer them and fail with `503 Please try again later` while the app
-  starts up. The `driver_pool` URL in `api.toml` (step 5) must point at the same
-  port.
+  Keep the Engine's `[server]` port set to **8055**, and the `driver_pool` URL
+  in `api.toml` pointing at it. Cerebrium uses this port to tell when the Engine
+  is ready, so requests that arrive during startup are queued instead of failing
+  with `503 Please try again later`.
 </Warning>
 
 ```bash
@@ -93,8 +91,8 @@ server_url = ["https://license.deepgram.com"]
 ### The IP address to listen on. Since this is likely running in a Docker
 ### container, you will probably want to listen on all interfaces.
 host = "0.0.0.0"
-### The port to listen on. On Cerebrium this must stay 8055 — it is how the
-### platform detects that the Engine is ready to serve traffic.
+### The port to listen on. On Cerebrium, keep 8055 so requests are queued while
+### the Engine starts up.
 port = 8055
 
 

--- a/partner-services/deepgram.mdx
+++ b/partner-services/deepgram.mdx
@@ -61,11 +61,12 @@ cerebrium cp nova-3-general.en.streaming.123456.dg deepgram-models/nova-3-genera
    ```
 
 <Warning>
-  Leave the Engine's `[server]` port set to **8055**. Cerebrium watches this port
-  to tell when the Engine has finished loading your models and the app is ready to
-  serve traffic. If you change it, requests are sent before the Engine can answer
-  them and fail with `503 Please try again later` while the app starts up. The
-  `driver_pool` URL in `api.toml` (step 5) must point at the same port.
+  Leave the Engine's `[server]` port set to **8055**. Cerebrium watches this
+  port to tell when the Engine has finished loading your models and the app is
+  ready to serve traffic. If you change it, requests are sent before the Engine
+  can answer them and fail with `503 Please try again later` while the app
+  starts up. The `driver_pool` URL in `api.toml` (step 5) must point at the same
+  port.
 </Warning>
 
 ```bash

--- a/partner-services/deepgram.mdx
+++ b/partner-services/deepgram.mdx
@@ -60,6 +60,14 @@ cerebrium cp nova-3-general.en.streaming.123456.dg deepgram-models/nova-3-genera
    cerebrium cp engine.toml deepgram/engine.toml
    ```
 
+<Warning>
+  Leave the Engine's `[server]` port set to **8055**. Cerebrium watches this port
+  to tell when the Engine has finished loading your models and the app is ready to
+  serve traffic. If you change it, requests are sent before the Engine can answer
+  them and fail with `503 Please try again later` while the app starts up. The
+  `driver_pool` URL in `api.toml` (step 5) must point at the same port.
+</Warning>
+
 ```bash
 
 ### Keep in mind that all paths are in-container paths and do not need to exist
@@ -84,7 +92,8 @@ server_url = ["https://license.deepgram.com"]
 ### The IP address to listen on. Since this is likely running in a Docker
 ### container, you will probably want to listen on all interfaces.
 host = "0.0.0.0"
-### The port to listen on
+### The port to listen on. On Cerebrium this must stay 8055 — it is how the
+### platform detects that the Engine is ready to serve traffic.
 port = 8055
 
 
@@ -260,6 +269,8 @@ speak_streaming = true # or false
 ###
 ### Docker Compose and Podman Compose create a dedicated network that allows inter-container communication by app name.
 ### See [Networking in Compose](https://docs.docker.com/compose/networking/) for details.
+###
+### On Cerebrium, keep port 8055 here so it matches `[server]` in engine.toml.
 url = "https://0.0.0.0:8055/v2"
 ### Factor to increase the timeout by for each additional retry (for
 ### exponential backoff).


### PR DESCRIPTION
Self-hosted Deepgram apps take ~40s to load models on a cold start. Requests that arrive in that window are queued and served once the Engine is ready — but only if the Engine's `[server]` port is left at the documented `8055`, which Cerebrium uses to tell when it can serve. Change it and those requests fail with `503 Please try again later` instead.

- Warning before the `engine.toml` block: keep the port at `8055`, and keep `api.toml`'s `driver_pool` URL pointing at it.
- Same note inline in both snippets, since those get copied and edited.

No behaviour change — documents an existing requirement.