### PR TITLE
Expose the OpenAPI spec download in the contextual menu

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -246,6 +246,7 @@
     "options": [
       "copy",
       "view",
+      "download-spec",
       "assistant",
       "mcp",
       "add-mcp",


### PR DESCRIPTION
Adds `download-spec` to `contextual.options`, placed after `copy`/`view` so the "fetch the raw artifact" actions group together (array order controls menu order).

## Why

Our API reference is generated from a hosted spec (`navigation.versions[0].tabs[4].openapi.source` -> `https://s3.eu-west-1.amazonaws.com/www.cerebrium.ai/openapi_spec.json`, public, **71 paths**, 349 KB), and pages like `/docs/api-reference/apps/list-apps` are live. Until now the contextual menu offered no route to the spec itself, so an agent on an API page could read one endpoint's prose but not pick up the machine-readable contract.

Per https://www.mintlify.com/docs/ai/contextual-menu, `download-spec` "Downloads your deployment's OpenAPI spec" and **only appears on API reference pages**, so this is inert on the other 52 pages.

## Validation

`docs.json` validated against Mintlify's published schema (`https://mintlify.com/docs.json`, fetched live):

- Against the full schema: **1 root error on both base and this branch, identical**. It is an `anyOf` artifact, the theme union reporting `'maple' was expected` etc. because our theme is `mint`.
- Against the `mint` branch specifically: **1 error on both base and this branch, identical** (`Additional properties are not allowed ('css' was unexpected)`, a pre-existing real Mintlify feature their published schema has not caught up to).

Net: **zero new schema errors**, and `download-spec` passes the `contextual.options` enum.

## Not included

Also valid but deliberately left out: `grok`, `aistudio`, `devin`, `devin-desktop`, `devin-mcp` (worth adding only if those are target agents) and `download-pdf` (Enterprise plans only).