### PR TITLE
Correct disable_auth default to true

### DIFF
--- a/endpoints/inference-api.mdx
+++ b/endpoints/inference-api.mdx
@@ -3,7 +3,7 @@ title: "REST API"
 description: "Make authenticated HTTP requests to your Cerebrium endpoints"
 ---
 
-All functions on Cerebrium are accessible via authenticated POST requests by default, unless marked private by prefixing the function name with an underscore (e.g. `_private_function()`). Authenticate using the JWT token from the **API Keys** section of the dashboard.
+All functions on Cerebrium are accessible via POST requests, unless marked private by prefixing the function name with an underscore (e.g. `_private_function()`). Authenticate using the JWT token from the **API Keys** section of the dashboard. Endpoints require this token only when `cerebrium.toml` sets [`disable_auth = false`](/toml-reference/toml-reference) — authentication is disabled by default.
 
 ## Request format
 

--- a/toml-reference/toml-reference.mdx
+++ b/toml-reference/toml-reference.mdx
@@ -19,7 +19,7 @@ The `[cerebrium.deployment]` section defines core deployment settings.
 | --------------------------------- | -------- | ---------------------- | ------------------------------------------------------------------------------------------------------------ |
 | name                              | string   | required               | Desired app name                                                                                             |
 | python_version                    | string   | "3.12"                 | Python version to use (3.10, 3.11, 3.12)                                                                     |
-| disable_auth                      | boolean  | false                  | Disable default token-based authentication on app endpoints                                                  |
+| disable_auth                      | boolean  | true                   | Disable token-based authentication on app endpoints                                                          |
 | include                           | string[] | ["*"]                  | Files/patterns to include in deployment                                                                      |
 | exclude                           | string[] | [".*"]                 | Files/patterns to exclude from deployment                                                                    |
 | shell_commands                    | string[] | []                     | Commands to run at the end of the build                                                                      |
@@ -27,6 +27,12 @@ The `[cerebrium.deployment]` section defines core deployment settings.
 | docker_base_image_url             | string   | "debian:bookworm-slim" | Base Docker image                                                                                            |
 | use_uv                            | boolean  | false                  | Use UV for faster Python package installation                                                                |
 | deployment_initialization_timeout | integer  | 600 (10 minutes)       | The max time to wait for app initialisation during build before timing out. Value must be between 60 and 830 |
+
+<Warning>
+  `disable_auth` defaults to `true`, so omitting it leaves app endpoints
+  callable without a token. Set `disable_auth = false` to require the JWT token
+  described in the [REST API reference](/endpoints/inference-api).
+</Warning>
 
 <Info>
   Changes to python_version or docker_base_image_url trigger full rebuilds since


### PR DESCRIPTION
The TOML reference lists `disable_auth` as defaulting to `false`, and the REST API page says functions are "accessible via authenticated POST requests by default". Both are wrong: an app deployed with no `disable_auth` in `cerebrium.toml` has authentication disabled, so its endpoints are callable without a token.

- Flip the table default to `true`
- Add a warning under the table, since a flipped boolean in a table cell is easy to miss for a setting that decides whether endpoints are public
- Fix the contradicting "authenticated by default" sentence on the REST API page

The "Complete Example" block keeps its explicit `disable_auth = false` — that is a chosen value, not a default claim.

Verified the deployed default against the platform's app-create API. `prettier --check` passes on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)